### PR TITLE
Add TUI context usage indicator

### DIFF
--- a/src/tty-app.ts
+++ b/src/tty-app.ts
@@ -46,6 +46,12 @@ type TtyAppArgs = {
   permissions: PermissionManager
 }
 
+type ContextUsage = {
+  usedTokens: number
+  maxTokens: number
+  usedPercent: number
+}
+
 type PendingApproval = {
   request: PermissionRequest
   resolve: (result: PermissionPromptResult) => void
@@ -84,6 +90,53 @@ function getSessionStats(args: TtyAppArgs, state: ScreenState) {
     messageCount: args.messages.length,
     skillCount: args.tools.getSkills().length,
     mcpCount: args.tools.getMcpServers().length,
+  }
+}
+
+function estimateTextTokens(value: string): number {
+  const trimmed = value.trim()
+  if (!trimmed) return 0
+  // Keep estimation simple and stable: roughly 1 token per 4 chars.
+  return Math.max(1, Math.ceil(trimmed.length / 4))
+}
+
+function estimateContextUsage(messages: ChatMessage[]): ContextUsage {
+  const envOverride = Number(process.env.MINI_CODE_MAX_CONTEXT_TOKENS)
+  const maxTokens =
+    Number.isFinite(envOverride) && envOverride > 0
+      ? Math.floor(envOverride)
+      : 200_000
+
+  let usedTokens = 0
+  for (const message of messages) {
+    if (
+      message.role === 'system' ||
+      message.role === 'user' ||
+      message.role === 'assistant' ||
+      message.role === 'assistant_progress'
+    ) {
+      usedTokens += estimateTextTokens(message.content)
+      continue
+    }
+
+    if (message.role === 'assistant_tool_call') {
+      usedTokens += estimateTextTokens(message.toolName)
+      try {
+        usedTokens += estimateTextTokens(JSON.stringify(message.input))
+      } catch {
+        usedTokens += estimateTextTokens(String(message.input))
+      }
+      continue
+    }
+
+    usedTokens += estimateTextTokens(message.toolName)
+    usedTokens += estimateTextTokens(message.content)
+  }
+
+  return {
+    usedTokens,
+    maxTokens,
+    usedPercent: Number(((usedTokens / maxTokens) * 100).toFixed(1)),
   }
 }
 
@@ -427,6 +480,7 @@ function extractPathFromToolInput(input: unknown): string | null {
 }
 
 function renderScreen(args: TtyAppArgs, state: ScreenState): void {
+  const contextUsage = estimateContextUsage(args.messages)
   clearScreen()
   console.log(renderHeaderPanel(args, state))
   console.log('')
@@ -452,6 +506,7 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
         state.status,
         true,
         args.tools.getSkills().length > 0,
+        contextUsage,
       ),
     )
     return
@@ -482,6 +537,7 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
       state.status,
       true,
       args.tools.getSkills().length > 0,
+      contextUsage,
     ),
   )
 }

--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -20,6 +20,12 @@ const BRIGHT_CYAN = '\u001b[96m'
 const BRIGHT_YELLOW = '\u001b[93m'
 const BORDER = '\u001b[38;5;31m'
 
+type ContextUsage = {
+  usedTokens: number
+  maxTokens: number
+  usedPercent: number
+}
+
 function stripAnsi(input: string): string {
   return input.replace(/\u001b\[[0-9;]*m/g, '')
 }
@@ -111,6 +117,16 @@ function colorBadge(
   color: string,
 ): string {
   return `${color}[${label}]${RESET} ${BOLD}${value}${RESET}`
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}k`
+  }
+  return String(value)
 }
 
 function borderLine(kind: 'top' | 'bottom', width: number): string {
@@ -274,10 +290,20 @@ export function renderFooterBar(
   status: string | null,
   toolsEnabled: boolean,
   skillsEnabled: boolean,
+  contextUsage?: ContextUsage,
 ): string {
   const width = Math.max(60, process.stdout.columns ?? 100)
   const left = renderStatusLine(status)
-  const right = `${DIM}tools${RESET} ${toolsEnabled ? `${GREEN}on${RESET}` : `${RED}off${RESET}`} ${DIM}|${RESET} ${DIM}skills${RESET} ${skillsEnabled ? `${GREEN}on${RESET}` : `${RED}off${RESET}`}`
+  const usageColor =
+    (contextUsage?.usedPercent ?? 0) >= 90
+      ? BRIGHT_RED
+      : (contextUsage?.usedPercent ?? 0) >= 75
+        ? BRIGHT_YELLOW
+        : BRIGHT_GREEN
+  const contextPart = contextUsage
+    ? `${DIM}ctx${RESET} ${usageColor}${formatTokenCount(contextUsage.usedTokens)}/${formatTokenCount(contextUsage.maxTokens)} ${contextUsage.usedPercent.toFixed(1)}%${RESET}`
+    : `${DIM}ctx${RESET} ${DIM}n/a${RESET}`
+  const right = `${DIM}tools${RESET} ${toolsEnabled ? `${GREEN}on${RESET}` : `${RED}off${RESET}`} ${DIM}|${RESET} ${DIM}skills${RESET} ${skillsEnabled ? `${GREEN}on${RESET}` : `${RED}off${RESET}`} ${DIM}|${RESET} ${contextPart}`
   const gap = Math.max(1, width - stripAnsi(left).length - stripAnsi(right).length)
   return `${left}${' '.repeat(gap)}${right}`
 }


### PR DESCRIPTION
## Summary
- add a lightweight context usage estimator in MiniCode TUI runtime based on current conversation messages
- show context usage in footer as `ctx used/max percent`, with color thresholds for quick risk awareness
- keep implementation simple and maintainable, defaulting to a 200k context window with optional `MINI_CODE_MAX_CONTEXT_TOKENS` override

## Test plan
- [x] run `npm run check`
- [x] verify footer render path compiles with updated `renderFooterBar` signature
- [ ] run interactive TUI manually and confirm context usage updates across turns/tool calls


Made with [Cursor](https://cursor.com)