### PR TITLE
feat: add MiniCode-Python as external/MiniCode-Python submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/MiniCode-rs"]
 	path = external/MiniCode-rs
 	url = https://github.com/harkerhand/MiniCode-rs.git
+[submodule "external/MiniCode-Python"]
+	path = external/MiniCode-Python
+	url = https://github.com/QUSETIONS/MiniCode-Python.git


### PR DESCRIPTION
Add the Python version of MiniCode as a Git submodule under `external/MiniCode-Python`.

This follows the same pattern as PR #3 which added `external/MiniCode-rs`.

**Changes:**
- Updated `.gitmodules` with a new entry for `external/MiniCode-Python`
- Added submodule pointing to https://github.com/QUSETIONS/MiniCode-Python

**MiniCode-Python repo includes:**
- Complete Python implementation with bilingual README
- Cross-platform launch scripts
- 93+ performance optimizations
- Full feature parity