### PR TITLE
解决阿里千问等模型遇到的Anthropic协议的max_tokens问题

### DIFF
--- a/src/anthropic-adapter.ts
+++ b/src/anthropic-adapter.ts
@@ -1,6 +1,7 @@
 import type { ToolRegistry } from './tool.js'
 import type { ChatMessage, ModelAdapter, StepDiagnostics, ToolCall } from './types.js'
 import type { RuntimeConfig } from './config.js'
+import { resolveMaxOutputTokens } from './utils/context.js'
 
 const DEFAULT_MAX_RETRIES = 4
 const BASE_RETRY_DELAY_MS = 500
@@ -74,6 +75,10 @@ async function readJsonBody(response: Response): Promise<unknown> {
 }
 
 function extractErrorMessage(data: unknown, status: number): string {
+  if (typeof data === 'string' && data.trim()) {
+    return data.trim()
+  }
+
   if (
     typeof data === 'object' &&
     data !== null &&
@@ -81,10 +86,32 @@ function extractErrorMessage(data: unknown, status: number): string {
     typeof data.error === 'object' &&
     data.error !== null &&
     'message' in data.error &&
-    typeof data.error.message === 'string'
+    typeof data.error.message === 'string' &&
+    data.error.message.trim()
   ) {
-    return data.error.message
+    return data.error.message.trim()
   }
+
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'error' in data &&
+    typeof data.error === 'string' &&
+    data.error.trim()
+  ) {
+    return data.error.trim()
+  }
+
+  if (
+    typeof data === 'object' &&
+    data !== null &&
+    'message' in data &&
+    typeof data.message === 'string' &&
+    data.message.trim()
+  ) {
+    return data.message.trim()
+  }
+
   return `Model request failed: ${status}`
 }
 
@@ -227,6 +254,10 @@ export class AnthropicModelAdapter implements ModelAdapter {
     const runtime = await this.getRuntimeConfig()
     const payload = toAnthropicMessages(messages)
     const url = `${runtime.baseUrl.replace(/\/$/, '')}/v1/messages`
+    const maxOutputTokens = resolveMaxOutputTokens(
+      runtime.model,
+      runtime.maxOutputTokens,
+    )
 
     const headers: Record<string, string> = {
       'content-type': 'application/json',
@@ -248,9 +279,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
         description: tool.description,
         input_schema: tool.inputSchema,
       })),
-      ...(runtime.maxOutputTokens !== undefined
-        ? { max_tokens: runtime.maxOutputTokens }
-        : {}),
+      max_tokens: maxOutputTokens,
     }
 
     const maxRetries = getRetryLimit()

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,65 @@
+type ModelMaxOutputTokens = {
+  default: number
+  upperLimit: number
+}
+
+const UNKNOWN_MODEL_MAX_OUTPUT_TOKENS: ModelMaxOutputTokens = {
+  default: 32_000,
+  upperLimit: 64_000,
+}
+
+function includesAny(value: string, patterns: string[]): boolean {
+  return patterns.some(pattern => value.includes(pattern))
+}
+
+export function getModelMaxOutputTokens(model: string): ModelMaxOutputTokens {
+  const normalized = model.trim().toLowerCase()
+
+  if (normalized.includes('opus-4-6')) {
+    return { default: 64_000, upperLimit: 128_000 }
+  }
+
+  if (normalized.includes('sonnet-4-6')) {
+    return { default: 32_000, upperLimit: 128_000 }
+  }
+
+  if (includesAny(normalized, ['opus-4-5', 'sonnet-4', 'haiku-4'])) {
+    return { default: 32_000, upperLimit: 64_000 }
+  }
+
+  if (includesAny(normalized, ['opus-4-1', 'opus-4'])) {
+    return { default: 32_000, upperLimit: 32_000 }
+  }
+
+  if (
+    includesAny(normalized, [
+      'claude-3-sonnet',
+      '3-5-sonnet',
+      '3-5-haiku',
+    ])
+  ) {
+    return { default: 8_192, upperLimit: 8_192 }
+  }
+
+  if (includesAny(normalized, ['claude-3-opus', 'claude-3-haiku'])) {
+    return { default: 4_096, upperLimit: 4_096 }
+  }
+
+  return UNKNOWN_MODEL_MAX_OUTPUT_TOKENS
+}
+
+export function resolveMaxOutputTokens(
+  model: string,
+  configuredMaxOutputTokens?: number,
+): number {
+  const limits = getModelMaxOutputTokens(model)
+  if (
+    configuredMaxOutputTokens !== undefined &&
+    Number.isFinite(configuredMaxOutputTokens) &&
+    configuredMaxOutputTokens > 0
+  ) {
+    return Math.min(Math.floor(configuredMaxOutputTokens), limits.upperLimit)
+  }
+
+  return limits.default
+}


### PR DESCRIPTION
## Summary
- Always resolve and pass the `max_tokens` parameter in Anthropic requests, regardless of whether `maxOutputTokens` is explicitly set.
- The value of `max_tokens` is derived based on model-aware defaults and upper bounds: for unknown models, it defaults to `32000` with an upper cap of `64000`.

## Test plan
#### **qwen**
配置settings.json如
```json
{
  "model": "qwen3.6-plus",
  "env": {
    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
    "ANTHROPIC_AUTH_TOKEN": "your API key",
    "ANTHROPIC_MODEL": "qwen3.6-plus"
  },
  "mcpServers": {}
}
```

模型正常思考并返回结果

#### **deepseek**

配置settings.json如
```json
{
  "model": "deepseek-chat", 
  "env": {
    "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
    "ANTHROPIC_AUTH_TOKEN": "your API key",
    "ANTHROPIC_MODEL": "deepseek-chat" 
  },
  "mcpServers": {}
}
```

模型正常思考并返回结果

Made with [Codex](https://www.chatgpt.com/)