### PR TITLE
feat: custom config dir + mouse text selection in TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,23 @@ Configuration is stored in:
 - `~/.mini-code/settings.json`
 - `~/.mini-code/mcp.json`
 
+You can override the config directory with `MINI_CODE_HOME`:
+
+```bash
+export MINI_CODE_HOME=/path/to/custom/dir
+npm run install-local
+```
+
 The launcher is installed to:
 
 - `~/.local/bin/minicode`
+
+You can override the launcher directory with `MINI_CODE_BIN_DIR`:
+
+```bash
+export MINI_CODE_BIN_DIR=/path/to/custom/bin
+npm run install-local
+```
 
 If `~/.local/bin` is not already on your `PATH`, add:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,9 +155,23 @@ npm run install-local
 - `~/.mini-code/settings.json`
 - `~/.mini-code/mcp.json`
 
+你可以通过 `MINI_CODE_HOME` 自定义配置目录：
+
+```bash
+export MINI_CODE_HOME=/path/to/custom/dir
+npm run install-local
+```
+
 启动命令安装到：
 
 - `~/.local/bin/minicode`
+
+你可以通过 `MINI_CODE_BIN_DIR` 自定义启动器目录：
+
+```bash
+export MINI_CODE_BIN_DIR=/path/to/custom/bin
+npm run install-local
+```
 
 如果 `~/.local/bin` 不在你的 `PATH` 中，可以添加：
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,9 @@ export type RuntimeConfig = {
 
 export type McpConfigScope = 'user' | 'project'
 
-export const MINI_CODE_DIR = path.join(os.homedir(), '.mini-code')
+export const MINI_CODE_DIR = process.env.MINI_CODE_HOME
+  ? path.resolve(process.env.MINI_CODE_HOME)
+  : path.join(os.homedir(), '.mini-code')
 export const MINI_CODE_SETTINGS_PATH = path.join(MINI_CODE_DIR, 'settings.json')
 export const MINI_CODE_HISTORY_PATH = path.join(MINI_CODE_DIR, 'history.json')
 export const MINI_CODE_PERMISSIONS_PATH = path.join(MINI_CODE_DIR, 'permissions.json')

--- a/src/install.ts
+++ b/src/install.ts
@@ -86,7 +86,9 @@ async function main(): Promise<void> {
     })
 
     const home = os.homedir()
-    const targetBinDir = path.join(home, '.local', 'bin')
+    const targetBinDir = process.env.MINI_CODE_BIN_DIR
+      ? path.resolve(process.env.MINI_CODE_BIN_DIR)
+      : path.join(home, '.local', 'bin')
     const launcherPath = path.join(targetBinDir, 'minicode')
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
     const launcherScript = [

--- a/src/tty-app.ts
+++ b/src/tty-app.ts
@@ -15,6 +15,7 @@ import {
   PermissionRequest,
 } from './permissions.js'
 import { buildSystemPrompt } from './prompt.js'
+import { spawn } from 'node:child_process'
 import { parseInputChunk, type ParsedInputEvent } from './tui/input-parser.js'
 import {
   clearScreen,
@@ -33,7 +34,11 @@ import {
   renderTranscript,
   getTranscriptMaxScrollOffset,
   showCursor,
+  extractSelectedText,
+  renderTranscriptLines,
+  getTranscriptWindowSize,
   type TranscriptEntry,
+  type TranscriptSelection,
 } from './ui.js'
 import type { RuntimeConfig } from './config.js'
 import type { ToolRegistry } from './tool.js'
@@ -78,6 +83,8 @@ type ScreenState = {
   isBusy: boolean
   contextStats: ContextStats | null
   compressionStatus: string | null
+  selection: TranscriptSelection | null
+  mouseDown: { x: number; y: number } | null
 }
 
 type TranscriptEntryDraft =
@@ -146,6 +153,51 @@ function getMaxTranscriptScrollOffset(args: TtyAppArgs, state: ScreenState): num
     state.transcript,
     getTranscriptBodyLines(args, state),
   )
+}
+
+function getTranscriptBodyStartY(args: TtyAppArgs, state: ScreenState): number {
+  const headerLines = renderHeaderPanel(args, state).split('\n').length
+  // header + empty line + panel top border + panel title + panel empty row
+  return headerLines + 4
+}
+
+function screenToAbsoluteLineIndex(
+  args: TtyAppArgs,
+  state: ScreenState,
+  screenY: number,
+): number {
+  const bodyStartY = getTranscriptBodyStartY(args, state)
+  const bodyY = screenY - bodyStartY
+  if (bodyY < 0) return -1
+
+  const lines = renderTranscriptLines(state.transcript)
+  const pageSize = getTranscriptWindowSize(getTranscriptBodyLines(args, state))
+  const maxOffset = Math.max(0, lines.length - pageSize)
+  const offset = Math.max(0, Math.min(state.transcriptScrollOffset, maxOffset))
+  const end = lines.length - offset
+  const start = Math.max(0, end - pageSize)
+
+  const lineIndex = start + bodyY
+  if (lineIndex < 0 || lineIndex >= lines.length) return -1
+  return lineIndex
+}
+
+function copyToClipboard(text: string): void {
+  try {
+    const platform = process.platform
+    const proc =
+      platform === 'win32'
+        ? spawn('clip', { stdio: ['pipe', 'inherit', 'inherit'] })
+        : platform === 'darwin'
+          ? spawn('pbcopy', { stdio: ['pipe', 'inherit', 'inherit'] })
+          : spawn('xclip', ['-selection', 'clipboard'], {
+              stdio: ['pipe', 'inherit', 'inherit'],
+            })
+    proc.stdin?.write(text)
+    proc.stdin?.end()
+  } catch {
+    // Silently fail if clipboard is unavailable
+  }
 }
 
 function scrollTranscriptBy(
@@ -471,6 +523,7 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
             state.transcript,
             state.transcriptScrollOffset,
             getTranscriptBodyLines(args, state),
+            state.selection ?? undefined,
           )
         : `${renderStatusLine(null)}\n\nType /help for commands.`,
       {
@@ -939,6 +992,8 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
     isBusy: false,
     contextStats: null,
     compressionStatus: null,
+    selection: null,
+    mouseDown: null,
   }
   state.historyIndex = state.history.length
 
@@ -1165,6 +1220,64 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
           ) {
             renderScreen(permissionArgs, state)
           }
+          return
+        }
+
+        if (event.kind === 'mouse') {
+          const lineIndex = screenToAbsoluteLineIndex(permissionArgs, state, event.y)
+          if (lineIndex < 0) {
+            state.mouseDown = null
+            state.selection = null
+            return
+          }
+          const col = Math.max(0, event.x - 2)
+
+          if (event.action === 'press' && event.button === 'left') {
+            state.mouseDown = { x: col, y: lineIndex }
+            state.selection = null
+            renderScreen(permissionArgs, state)
+            return
+          }
+
+          if (event.action === 'drag' && event.button === 'left' && state.mouseDown) {
+            const startLine = Math.min(state.mouseDown.y, lineIndex)
+            const endLine = Math.max(state.mouseDown.y, lineIndex)
+            const startCol =
+              startLine === state.mouseDown.y
+                ? Math.min(state.mouseDown.x, col)
+                : state.mouseDown.y < lineIndex
+                  ? state.mouseDown.x
+                  : col
+            const endCol =
+              endLine === state.mouseDown.y
+                ? Math.max(state.mouseDown.x, col)
+                : state.mouseDown.y > lineIndex
+                  ? state.mouseDown.x
+                  : col
+
+            state.selection = {
+              startLine,
+              startCol,
+              endLine,
+              endCol,
+            }
+            renderScreen(permissionArgs, state)
+            return
+          }
+
+          if (event.action === 'release' && event.button === 'left' && state.mouseDown) {
+            if (state.selection) {
+              const text = extractSelectedText(state.transcript, state.selection)
+              if (text) {
+                copyToClipboard(text)
+              }
+            }
+            state.mouseDown = null
+            state.selection = null
+            renderScreen(permissionArgs, state)
+            return
+          }
+
           return
         }
 

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -11,5 +11,6 @@ export {
 } from './chrome.js'
 export { renderInputPrompt } from './input.js'
 export { clearScreen, enterAlternateScreen, exitAlternateScreen, hideCursor, showCursor } from './screen.js'
-export { renderTranscript, getTranscriptMaxScrollOffset, getTranscriptWindowSize } from './transcript.js'
+export { renderTranscript, getTranscriptMaxScrollOffset, getTranscriptWindowSize, extractSelectedText, renderTranscriptLines } from './transcript.js'
 export type { TranscriptEntry } from './types.js'
+export type { TranscriptSelection } from './transcript.js'

--- a/src/tui/input-parser.ts
+++ b/src/tui/input-parser.ts
@@ -30,6 +30,13 @@ type ParsedInputEvent =
       kind: 'wheel'
       direction: 'up' | 'down'
     }
+  | {
+      kind: 'mouse'
+      x: number
+      y: number
+      button: 'left' | 'middle' | 'right'
+      action: 'press' | 'release' | 'drag'
+    }
 
 type ParseResult = {
   events: ParsedInputEvent[]
@@ -72,6 +79,9 @@ function parseEscapeSequence(input: string): {
   let match = /^\u001b\[<(\d+);(\d+);(\d+)([Mm])/.exec(input)
   if (match) {
     const button = Number(match[1])
+    const x = Number(match[2]) - 1
+    const y = Number(match[3]) - 1
+    const released = match[4] === 'm'
     const length = match[0].length
     if ((button & 0x43) === 0x40) {
       return { event: { kind: 'wheel', direction: 'up' }, length }
@@ -79,7 +89,20 @@ function parseEscapeSequence(input: string): {
     if ((button & 0x43) === 0x41) {
       return { event: { kind: 'wheel', direction: 'down' }, length }
     }
-    return { event: null, length }
+    const btnCode = button & 0x43
+    const isDrag = (button & 0x20) !== 0
+    const buttonName: 'left' | 'middle' | 'right' =
+      btnCode === 0 ? 'left' : btnCode === 1 ? 'middle' : 'right'
+    return {
+      event: {
+        kind: 'mouse',
+        x,
+        y,
+        button: buttonName,
+        action: released ? 'release' : isDrag ? 'drag' : 'press',
+      },
+      length,
+    }
   }
 
   if (/^\u001b\[M.../.test(input)) {
@@ -191,11 +214,6 @@ export function parseInputChunk(
 
   while (index < input.length) {
     const remaining = input.slice(index)
-
-    if (/^\[<\d+;\d+;\d+[Mm]/.test(remaining)) {
-      index += remaining.match(/^\[<\d+;\d+;\d+[Mm]/)?.[0].length ?? 1
-      continue
-    }
 
     if (remaining[0] === ESC) {
       if (maybeNeedMoreForEscapeSequence(remaining)) {

--- a/src/tui/transcript.ts
+++ b/src/tui/transcript.ts
@@ -2,15 +2,76 @@ import process from 'node:process'
 import { renderMarkdownish } from './markdown.js'
 import type { TranscriptEntry } from './types.js'
 
-const RESET = '\u001b[0m'
-const DIM = '\u001b[2m'
-const CYAN = '\u001b[36m'
-const GREEN = '\u001b[32m'
-const YELLOW = '\u001b[33m'
-const RED = '\u001b[31m'
-const MAGENTA = '\u001b[35m'
-const BOLD = '\u001b[1m'
-const BLUE = '\u001b[34m'
+const RESET = '[0m'
+const DIM = '[2m'
+const CYAN = '[36m'
+const GREEN = '[32m'
+const YELLOW = '[33m'
+const RED = '[31m'
+const MAGENTA = '[35m'
+const BOLD = '[1m'
+const BLUE = '[34m'
+const REVERSE = '[7m'
+
+export type TranscriptSelection = {
+  startLine: number
+  startCol: number
+  endLine: number
+  endCol: number
+}
+
+function stripAnsi(str: string): string {
+  return str.replace(/\[[\d;]*[A-Za-z]/g, '')
+}
+
+function highlightRange(line: string, startCol: number, endCol: number): string {
+  if (startCol >= endCol) return line
+
+  let result = ''
+  let visibleIndex = 0
+  let i = 0
+  let highlighted = false
+
+  while (i < line.length) {
+    if (line[i] === '') {
+      const escapeStart = i
+      i++
+      if (i < line.length && line[i] === '[') {
+        i++
+        while (i < line.length && (line[i] < '@' || line[i] > '~')) {
+          i++
+        }
+        i++
+      }
+      const seq = line.slice(escapeStart, i)
+      result += seq
+      if (seq === '[0m' && highlighted) {
+        result += REVERSE
+      }
+      continue
+    }
+
+    if (!highlighted && visibleIndex === startCol) {
+      result += REVERSE
+      highlighted = true
+    }
+
+    if (highlighted && visibleIndex === endCol) {
+      result += RESET
+      highlighted = false
+    }
+
+    result += line[i]
+    visibleIndex++
+    i++
+  }
+
+  if (highlighted) {
+    result += RESET
+  }
+
+  return result
+}
 
 function indentBlock(input: string, prefix = '  '): string {
   return input
@@ -81,7 +142,7 @@ export function getTranscriptWindowSize(windowSize?: number): number {
   return Math.max(8, rows - 15)
 }
 
-function renderTranscriptLines(entries: TranscriptEntry[]): string[] {
+export function renderTranscriptLines(entries: TranscriptEntry[]): string[] {
   const rendered = entries.map(renderTranscriptEntry)
   const separator = `${BLUE}${DIM}·${RESET}`
   const lines: string[] = []
@@ -112,17 +173,37 @@ export function renderTranscript(
   entries: TranscriptEntry[],
   scrollOffset: number,
   windowSize?: number,
+  selection?: TranscriptSelection,
 ): string {
   if (entries.length === 0) {
     return ''
   }
 
-  const lines = renderTranscriptLines(entries)
+  let lines = renderTranscriptLines(entries)
   const pageSize = getTranscriptWindowSize(windowSize)
   const maxOffset = Math.max(0, lines.length - pageSize)
   const offset = Math.max(0, Math.min(scrollOffset, maxOffset))
   const end = lines.length - offset
   const start = Math.max(0, end - pageSize)
+
+  if (selection) {
+    lines = lines.map((line, index) => {
+      if (index < selection.startLine || index > selection.endLine) {
+        return line
+      }
+      if (index === selection.startLine && index === selection.endLine) {
+        return highlightRange(line, selection.startCol, selection.endCol)
+      }
+      if (index === selection.startLine) {
+        return highlightRange(line, selection.startCol, Infinity)
+      }
+      if (index === selection.endLine) {
+        return highlightRange(line, 0, selection.endCol)
+      }
+      return highlightRange(line, 0, Infinity)
+    })
+  }
+
   const body = lines.slice(start, end).join('\n')
 
   if (offset === 0) {
@@ -130,4 +211,27 @@ export function renderTranscript(
   }
 
   return `${body}\n\n${DIM}scroll offset: ${offset}${RESET}`
+}
+
+export function extractSelectedText(
+  entries: TranscriptEntry[],
+  selection: TranscriptSelection,
+): string {
+  const lines = renderTranscriptLines(entries)
+  const { startLine, startCol, endLine, endCol } = selection
+
+  const result: string[] = []
+  for (let i = startLine; i <= endLine && i < lines.length; i++) {
+    const plainLine = stripAnsi(lines[i])
+    if (i === startLine && i === endLine) {
+      result.push(plainLine.slice(startCol, endCol))
+    } else if (i === startLine) {
+      result.push(plainLine.slice(startCol))
+    } else if (i === endLine) {
+      result.push(plainLine.slice(0, endCol))
+    } else {
+      result.push(plainLine)
+    }
+  }
+  return result.join('\n')
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -17,6 +17,9 @@ export {
   renderToolPanel,
   renderTranscript,
   showCursor,
+  extractSelectedText,
+  renderTranscriptLines,
 } from './tui/index.js'
 
 export type { TranscriptEntry } from './tui/index.js'
+export type { TranscriptSelection } from './tui/index.js'


### PR DESCRIPTION
## Summary

This PR adds two features:
1. **Custom config directory** via `MINI_CODE_HOME` and `MINI_CODE_BIN_DIR` env vars
2. **Mouse text selection** in the TUI transcript with auto-copy to clipboard

## Feature 1: Custom Config Directory

Allow users to override the default `~/.mini-code` config location and `~/.local/bin` launcher location.

```bash
export MINI_CODE_HOME=/path/to/config
export MINI_CODE_BIN_DIR=/path/to/bin
npm run install-local
```

Closes #11

## Feature 2: Mouse Text Selection

Users can now click and drag to select text in the transcript area. Selected text is automatically copied to the system clipboard on release.

### How it works
- Left-click to start selection
- Drag to expand selection
- Release to copy highlighted text to clipboard
- Selection auto-clears after copy

### Supported platforms
- Windows: `clip`
- macOS: `pbcopy`
- Linux: `xclip`

Closes #13

## Changes

- `src/config.ts`: `MINI_CODE_HOME` support
- `src/install.ts`: `MINI_CODE_BIN_DIR` support
- `src/tui/input-parser.ts`: mouse press/drag/release event parsing
- `src/tui/transcript.ts`: selection highlight + text extraction
- `src/tty-app.ts`: mouse event handling + clipboard copy
- `README.md` / `README.zh-CN.md`: document new env vars

## Checklist

- [x] Backward compatible
- [x] No new dependencies
- [x] `npm run check` passes
- [x] Closes #11
- [x] Closes #13