### PR TITLE
feat: support MINI_CODE_HOME and MINI_CODE_BIN_DIR env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,23 @@ Configuration is stored in:
 - `~/.mini-code/settings.json`
 - `~/.mini-code/mcp.json`
 
+You can override the config directory with `MINI_CODE_HOME`:
+
+```bash
+export MINI_CODE_HOME=/path/to/custom/dir
+npm run install-local
+```
+
 The launcher is installed to:
 
 - `~/.local/bin/minicode`
+
+You can override the launcher directory with `MINI_CODE_BIN_DIR`:
+
+```bash
+export MINI_CODE_BIN_DIR=/path/to/custom/bin
+npm run install-local
+```
 
 If `~/.local/bin` is not already on your `PATH`, add:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,9 +155,23 @@ npm run install-local
 - `~/.mini-code/settings.json`
 - `~/.mini-code/mcp.json`
 
+你可以通过 `MINI_CODE_HOME` 自定义配置目录：
+
+```bash
+export MINI_CODE_HOME=/path/to/custom/dir
+npm run install-local
+```
+
 启动命令安装到：
 
 - `~/.local/bin/minicode`
+
+你可以通过 `MINI_CODE_BIN_DIR` 自定义启动器目录：
+
+```bash
+export MINI_CODE_BIN_DIR=/path/to/custom/bin
+npm run install-local
+```
 
 如果 `~/.local/bin` 不在你的 `PATH` 中，可以添加：
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,9 @@ export type RuntimeConfig = {
 
 export type McpConfigScope = 'user' | 'project'
 
-export const MINI_CODE_DIR = path.join(os.homedir(), '.mini-code')
+export const MINI_CODE_DIR = process.env.MINI_CODE_HOME
+  ? path.resolve(process.env.MINI_CODE_HOME)
+  : path.join(os.homedir(), '.mini-code')
 export const MINI_CODE_SETTINGS_PATH = path.join(MINI_CODE_DIR, 'settings.json')
 export const MINI_CODE_HISTORY_PATH = path.join(MINI_CODE_DIR, 'history.json')
 export const MINI_CODE_PERMISSIONS_PATH = path.join(MINI_CODE_DIR, 'permissions.json')

--- a/src/install.ts
+++ b/src/install.ts
@@ -86,7 +86,9 @@ async function main(): Promise<void> {
     })
 
     const home = os.homedir()
-    const targetBinDir = path.join(home, '.local', 'bin')
+    const targetBinDir = process.env.MINI_CODE_BIN_DIR
+      ? path.resolve(process.env.MINI_CODE_BIN_DIR)
+      : path.join(home, '.local', 'bin')
     const launcherPath = path.join(targetBinDir, 'minicode')
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
     const launcherScript = [


### PR DESCRIPTION
## Summary

Allow users to override the default `~/.mini-code` config directory and `~/.local/bin` launcher directory via environment variables.

## Problem

Config and launcher locations are hardcoded:
- Config: `~/.mini-code/`
- Launcher: `~/.local/bin/minicode`

This is inconvenient for:
- Windows users with limited C: drive space
- Users who want to sync settings across machines

## Solution

Two new environment variables:

| Variable | Default | Purpose |
|----------|---------|---------|
| `MINI_CODE_HOME` | `~/.mini-code` | Config directory (settings, history, mcp) |
| `MINI_CODE_BIN_DIR` | `~/.local/bin` | Launcher script directory |

## Usage

```bash
# Windows
set MINI_CODE_HOME=D:\minicode-data
set MINI_CODE_BIN_DIR=D:\minicode-datain
npm run install-local

# Linux/macOS
export MINI_CODE_HOME=/mnt/data/minicode
export MINI_CODE_BIN_DIR=/mnt/data/minicode/bin
npm run install-local
```

## Changes

- `src/config.ts`: `MINI_CODE_HOME` overrides config dir
- `src/install.ts`: `MINI_CODE_BIN_DIR` overrides launcher dir
- `README.md` / `README.zh-CN.md`: document both variables

## Checklist

- [x] Backward compatible (falls back to defaults if env vars not set)
- [x] No new dependencies
- [x] `npm run check` passes
- [x] Closes #11