### PR TITLE
 feat: add mouse text selection and copy in TUI transcript

### DIFF
--- a/src/tty-app.ts
+++ b/src/tty-app.ts
@@ -29,6 +29,7 @@ import {
   listAllProjects,
 } from './session.js'
 import type { SessionMeta, ProjectMeta } from './session.js'
+import { spawn } from 'node:child_process'
 import { parseInputChunk, type ParsedInputEvent } from './tui/input-parser.js'
 import {
   clearScreen,
@@ -47,7 +48,11 @@ import {
   renderTranscript,
   getTranscriptMaxScrollOffset,
   showCursor,
+  extractSelectedText,
+  renderTranscriptLines,
+  getTranscriptWindowSize,
   type TranscriptEntry,
+  type TranscriptSelection,
 } from './ui.js'
 import type { RuntimeConfig } from './config.js'
 import type { ToolRegistry } from './tool.js'
@@ -111,6 +116,10 @@ type ScreenState = {
   isBusy: boolean
   contextStats: ContextStats | null
   compressionStatus: string | null
+  selection: TranscriptSelection | null
+  mouseDown: { x: number; y: number } | null
+  transcriptBodyStartY: number
+  transcriptBodyLines: number
 }
 
 type TranscriptEntryDraft =
@@ -128,6 +137,12 @@ function formatRelativeTime(timestamp: number): string {
   if (hours < 24) return `${hours}h ago`
   const days = Math.floor(hours / 24)
   return `${days}d ago`
+}
+
+export function keepSelectionAfterMouseRelease(
+  selection: TranscriptSelection | null,
+): TranscriptSelection | null {
+  return selection
 }
 
 function getSessionStats(args: TtyAppArgs, state: ScreenState) {
@@ -190,6 +205,57 @@ function getMaxTranscriptScrollOffset(args: TtyAppArgs, state: ScreenState): num
     state.transcript,
     getTranscriptBodyLines(args, state),
   )
+}
+
+function screenToAbsoluteLineIndex(
+  _args: TtyAppArgs,
+  state: ScreenState,
+  screenY: number,
+): number {
+  const bodyStartY = state.transcriptBodyStartY
+  const bodyY = screenY - bodyStartY
+  if (bodyY < 0) return -1
+
+  const lines = renderTranscriptLines(state.transcript)
+  const pageSize = getTranscriptWindowSize(state.transcriptBodyLines)
+  const maxOffset = Math.max(0, lines.length - pageSize)
+  const offset = Math.max(0, Math.min(state.transcriptScrollOffset, maxOffset))
+  const end = lines.length - offset
+  const start = Math.max(0, end - pageSize)
+
+  const lineIndex = start + bodyY
+  if (lineIndex < 0) return -1
+  if (lines.length === 0) return -1
+  return Math.min(lineIndex, lines.length - 1)
+}
+
+export function encodeClipboardTextForPlatform(
+  platform: NodeJS.Platform,
+  text: string,
+): string | Buffer {
+  if (platform === 'win32') {
+    return Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')])
+  }
+  return text
+}
+
+function copyToClipboard(text: string): void {
+  try {
+    const platform = process.platform
+    const proc =
+      platform === 'win32'
+        ? spawn('clip', { stdio: ['pipe', 'inherit', 'inherit'] })
+        : platform === 'darwin'
+          ? spawn('pbcopy', { stdio: ['pipe', 'inherit', 'inherit'] })
+          : spawn('xclip', ['-selection', 'clipboard'], {
+              stdio: ['pipe', 'inherit', 'inherit'],
+            })
+    const payload = encodeClipboardTextForPlatform(platform, text)
+    proc.stdin?.write(payload)
+    proc.stdin?.end()
+  } catch {
+    // Silently fail if clipboard is unavailable
+  }
 }
 
 function scrollTranscriptBy(
@@ -478,8 +544,11 @@ function extractPathFromToolInput(input: unknown): string | null {
 function renderScreen(args: TtyAppArgs, state: ScreenState): void {
   const backgroundTasks = listBackgroundTasks()
   clearScreen()
-  console.log(renderHeaderPanel(args, state))
+  const headerPanel = renderHeaderPanel(args, state)
+  console.log(headerPanel)
   console.log('')
+  state.transcriptBodyStartY = headerPanel.split('\n').length + 4
+  state.transcriptBodyLines = getTranscriptBodyLines(args, state)
 
   if (state.pendingApproval) {
     console.log(
@@ -550,6 +619,7 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
             state.transcript,
             state.transcriptScrollOffset,
             getTranscriptBodyLines(args, state),
+            state.selection ?? undefined,
           )
         : `${renderStatusLine(null)}\n\nType /help for commands.`,
       {
@@ -1184,6 +1254,10 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
     isBusy: false,
     contextStats: null,
     compressionStatus: null,
+    selection: null,
+    mouseDown: null,
+    transcriptBodyStartY: 0,
+    transcriptBodyLines: 20,
   }
   state.historyIndex = state.history.length
 
@@ -1572,6 +1646,67 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
           }
           return
         }
+
+        if (event.kind === 'mouse') {
+          const screenX = event.x + 1
+          const screenY = event.y + 1
+          const lineIndex = screenToAbsoluteLineIndex(permissionArgs, state, screenY)
+          if (lineIndex < 0) {
+            state.mouseDown = null
+            state.selection = null
+            return
+          }
+          const col = Math.max(0, screenX - 3)  // panel border (2) + content starts after left padding space
+
+          if (event.action === 'press' && event.button === 'left') {
+            state.mouseDown = { x: col, y: lineIndex }
+            state.selection = null
+            renderScreen(permissionArgs, state)
+            return
+          }
+
+          if (event.action === 'drag' && event.button === 'left' && state.mouseDown) {
+            const startLine = Math.min(state.mouseDown.y, lineIndex)
+            const endLine = Math.max(state.mouseDown.y, lineIndex)
+            const startCol =
+              startLine === state.mouseDown.y
+                ? Math.min(state.mouseDown.x, col)
+                : state.mouseDown.y < lineIndex
+                  ? state.mouseDown.x
+                  : col
+            const endCol =
+              endLine === state.mouseDown.y
+                ? Math.max(state.mouseDown.x, col)
+                : state.mouseDown.y > lineIndex
+                  ? state.mouseDown.x
+                  : col
+
+            state.selection = {
+              startLine,
+              startCol,
+              endLine,
+              endCol,
+            }
+            renderScreen(permissionArgs, state)
+            return
+          }
+
+          if (event.action === 'release' && state.mouseDown) {
+            if (state.selection) {
+              const text = extractSelectedText(state.transcript, state.selection)
+              if (text) {
+                copyToClipboard(text)
+              }
+            }
+            state.mouseDown = null
+            state.selection = keepSelectionAfterMouseRelease(state.selection)
+            renderScreen(permissionArgs, state)
+            return
+          }
+
+          return
+        }
+
 
         if (event.kind === 'key' && event.name === 'return') {
           if (state.isBusy) {

--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -25,7 +25,7 @@ function stripAnsi(input: string): string {
   return input.replace(/\u001b\[[0-9;]*m/g, '')
 }
 
-function charDisplayWidth(char: string): number {
+export function charDisplayWidth(char: string): number {
   const code = char.codePointAt(0)
   if (code === undefined) return 0
 
@@ -52,7 +52,7 @@ function charDisplayWidth(char: string): number {
   return 1
 }
 
-function stringDisplayWidth(input: string): number {
+export function stringDisplayWidth(input: string): number {
   return [...stripAnsi(input)].reduce((sum, char) => sum + charDisplayWidth(char), 0)
 }
 
@@ -173,7 +173,7 @@ function emptyPanelRow(width: number): string {
   return `${BORDER}│${RESET}${' '.repeat(Math.max(0, width - 2))}${BORDER}│${RESET}`
 }
 
-function wrapPanelBodyLine(line: string, width: number): string[] {
+export function wrapPanelBodyLine(line: string, width: number): string[] {
   const inner = Math.max(0, width - 4)
   if (inner <= 0) return ['']
   const plain = stripAnsi(line)

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -11,5 +11,6 @@ export {
 } from './chrome.js'
 export { renderInputPrompt } from './input.js'
 export { clearScreen, enterAlternateScreen, exitAlternateScreen, hideCursor, showCursor } from './screen.js'
-export { renderTranscript, getTranscriptMaxScrollOffset, getTranscriptWindowSize } from './transcript.js'
+export { renderTranscript, getTranscriptMaxScrollOffset, getTranscriptWindowSize, extractSelectedText, renderTranscriptLines } from './transcript.js'
 export type { TranscriptEntry } from './types.js'
+export type { TranscriptSelection } from './transcript.js'

--- a/src/tui/input-parser.ts
+++ b/src/tui/input-parser.ts
@@ -30,6 +30,13 @@ type ParsedInputEvent =
       kind: 'wheel'
       direction: 'up' | 'down'
     }
+  | {
+      kind: 'mouse'
+      x: number
+      y: number
+      button: 'left' | 'middle' | 'right'
+      action: 'press' | 'release' | 'drag'
+    }
 
 type ParseResult = {
   events: ParsedInputEvent[]
@@ -76,6 +83,9 @@ function parseEscapeSequence(input: string): {
   let match = /^\u001b\[<(\d+);(\d+);(\d+)([Mm])/.exec(input)
   if (match) {
     const button = Number(match[1])
+    const x = Number(match[2]) - 1
+    const y = Number(match[3]) - 1
+    const released = match[4] === 'm'
     const length = match[0].length
     if ((button & 0x43) === 0x40) {
       return { event: { kind: 'wheel', direction: 'up' }, length }
@@ -83,7 +93,20 @@ function parseEscapeSequence(input: string): {
     if ((button & 0x43) === 0x41) {
       return { event: { kind: 'wheel', direction: 'down' }, length }
     }
-    return { event: null, length }
+    const btnCode = button & 0x43
+    const isDrag = (button & 0x20) !== 0
+    const buttonName: 'left' | 'middle' | 'right' =
+      btnCode === 0 ? 'left' : btnCode === 1 ? 'middle' : 'right'
+    return {
+      event: {
+        kind: 'mouse',
+        x,
+        y,
+        button: buttonName,
+        action: released ? 'release' : isDrag ? 'drag' : 'press',
+      },
+      length,
+    }
   }
 
   if (/^\u001b\[M.../.test(input)) {
@@ -197,11 +220,6 @@ export function parseInputChunk(
 
   while (index < input.length) {
     const remaining = input.slice(index)
-
-    if (/^\[<\d+;\d+;\d+[Mm]/.test(remaining)) {
-      index += remaining.match(/^\[<\d+;\d+;\d+[Mm]/)?.[0].length ?? 1
-      continue
-    }
 
     if (remaining[0] === ESC) {
       if (maybeNeedMoreForEscapeSequence(remaining)) {

--- a/src/tui/screen.ts
+++ b/src/tui/screen.ts
@@ -1,20 +1,22 @@
 import process from 'node:process'
 
-const ENTER_ALT_SCREEN = '\u001b[?1049h'
-const EXIT_ALT_SCREEN = '\u001b[?1049l'
-const ERASE_SCREEN_AND_HOME = '\u001b[2J\u001b[H'
+const ENTER_ALT_SCREEN = '[?1049h'
+const EXIT_ALT_SCREEN = '[?1049l'
+const ERASE_SCREEN_AND_HOME = '[2J[H'
 const ENABLE_MOUSE_TRACKING =
-  '\u001b[?1000h' +
-  '\u001b[?1006h'
+  '[?1000h' +
+  '[?1002h' +
+  '[?1006h'
 const DISABLE_MOUSE_TRACKING =
-  '\u001b[?1006l' +
-  '\u001b[?1000l'
+  '[?1006l' +
+  '[?1002l' +
+  '[?1000l'
 export function hideCursor(): void {
-  process.stdout.write('\u001b[?25l')
+  process.stdout.write('[?25l')
 }
 
 export function showCursor(): void {
-  process.stdout.write('\u001b[?25h')
+  process.stdout.write('[?25h')
 }
 
 export function enterAlternateScreen(): void {
@@ -29,5 +31,5 @@ export function exitAlternateScreen(): void {
 
 export function clearScreen(): void {
   // Softer redraw than full clear to reduce visible flicker.
-  process.stdout.write('\u001b[H\u001b[J')
+  process.stdout.write('[H[J')
 }

--- a/src/tui/transcript.ts
+++ b/src/tui/transcript.ts
@@ -1,16 +1,112 @@
 import process from 'node:process'
+import { charDisplayWidth, wrapPanelBodyLine } from './chrome.js'
 import { renderMarkdownish } from './markdown.js'
 import type { TranscriptEntry } from './types.js'
 
-const RESET = '\u001b[0m'
-const DIM = '\u001b[2m'
-const CYAN = '\u001b[36m'
-const GREEN = '\u001b[32m'
-const YELLOW = '\u001b[33m'
-const RED = '\u001b[31m'
-const MAGENTA = '\u001b[35m'
-const BOLD = '\u001b[1m'
-const BLUE = '\u001b[34m'
+const RESET = '[0m'
+const DIM = '[2m'
+const CYAN = '[36m'
+const GREEN = '[32m'
+const YELLOW = '[33m'
+const RED = '[31m'
+const MAGENTA = '[35m'
+const BOLD = '[1m'
+const BLUE = '[34m'
+const REVERSE = '[7m'
+
+export type TranscriptSelection = {
+  startLine: number
+  startCol: number
+  endLine: number
+  endCol: number
+}
+
+function stripAnsi(str: string): string {
+  return str.replace(/\[[\d;]*[A-Za-z]/g, '')
+}
+
+function sliceByDisplayColumns(input: string, startCol: number, endCol: number): string {
+  if (startCol >= endCol) return ''
+
+  let result = ''
+  let col = 0
+  for (const char of input) {
+    const width = charDisplayWidth(char)
+    const nextCol = col + width
+    if (nextCol <= startCol) {
+      col = nextCol
+      continue
+    }
+    if (col >= endCol) {
+      break
+    }
+    result += char
+    col = nextCol
+  }
+  return result
+}
+
+function highlightRange(line: string, startCol: number, endCol: number): string {
+  if (startCol >= endCol) return line
+
+  let result = ''
+  let visibleCol = 0
+  let i = 0
+  let highlighted = false
+
+  while (i < line.length) {
+    if (line[i] === '') {
+      const escapeStart = i
+      i++
+      if (i < line.length && line[i] === '[') {
+        i++
+        while (i < line.length && (line[i] < '@' || line[i] > '~')) {
+          i++
+        }
+        i++
+      }
+      const seq = line.slice(escapeStart, i)
+      result += seq
+      if (seq === '[0m' && highlighted) {
+        result += REVERSE
+      }
+      continue
+    }
+
+    const char = line[i]
+    const width = charDisplayWidth(char)
+
+    if (!highlighted && visibleCol >= startCol) {
+      result += REVERSE
+      highlighted = true
+    }
+
+    if (!highlighted && visibleCol < startCol && visibleCol + width > startCol) {
+      result += REVERSE
+      highlighted = true
+    }
+
+    if (highlighted && visibleCol >= endCol) {
+      result += RESET
+      highlighted = false
+    }
+
+    result += char
+    visibleCol += width
+    i++
+
+    if (highlighted && visibleCol >= endCol) {
+      result += RESET
+      highlighted = false
+    }
+  }
+
+  if (highlighted) {
+    result += RESET
+  }
+
+  return result
+}
 
 function indentBlock(input: string, prefix = '  '): string {
   return input
@@ -73,6 +169,10 @@ function renderTranscriptEntry(entry: TranscriptEntry): string {
   return `${MAGENTA}${BOLD}tool${RESET} ${entry.toolName} ${status}\n${indentBlock(body)}`
 }
 
+function getTranscriptPanelWidth(): number {
+  return Math.max(60, process.stdout.columns ?? 100)
+}
+
 export function getTranscriptWindowSize(windowSize?: number): number {
   if (windowSize !== undefined) {
     return Math.max(4, windowSize)
@@ -81,22 +181,23 @@ export function getTranscriptWindowSize(windowSize?: number): number {
   return Math.max(8, rows - 15)
 }
 
-function renderTranscriptLines(entries: TranscriptEntry[]): string[] {
+export function renderTranscriptLines(entries: TranscriptEntry[]): string[] {
   const rendered = entries.map(renderTranscriptEntry)
   const separator = `${BLUE}${DIM}·${RESET}`
-  const lines: string[] = []
+  const logicalLines: string[] = []
 
   rendered.forEach((block, index) => {
     if (index > 0) {
-      lines.push('')
-      lines.push(separator)
-      lines.push('')
+      logicalLines.push('')
+      logicalLines.push(separator)
+      logicalLines.push('')
     }
 
-    lines.push(...block.split('\n'))
+    logicalLines.push(...block.split('\n'))
   })
 
-  return lines
+  const panelWidth = getTranscriptPanelWidth()
+  return logicalLines.flatMap(line => wrapPanelBodyLine(line, panelWidth))
 }
 
 export function getTranscriptMaxScrollOffset(
@@ -112,17 +213,37 @@ export function renderTranscript(
   entries: TranscriptEntry[],
   scrollOffset: number,
   windowSize?: number,
+  selection?: TranscriptSelection,
 ): string {
   if (entries.length === 0) {
     return ''
   }
 
-  const lines = renderTranscriptLines(entries)
+  let lines = renderTranscriptLines(entries)
   const pageSize = getTranscriptWindowSize(windowSize)
   const maxOffset = Math.max(0, lines.length - pageSize)
   const offset = Math.max(0, Math.min(scrollOffset, maxOffset))
   const end = lines.length - offset
   const start = Math.max(0, end - pageSize)
+
+  if (selection) {
+    lines = lines.map((line, index) => {
+      if (index < selection.startLine || index > selection.endLine) {
+        return line
+      }
+      if (index === selection.startLine && index === selection.endLine) {
+        return highlightRange(line, selection.startCol, selection.endCol)
+      }
+      if (index === selection.startLine) {
+        return highlightRange(line, selection.startCol, Infinity)
+      }
+      if (index === selection.endLine) {
+        return highlightRange(line, 0, selection.endCol)
+      }
+      return highlightRange(line, 0, Infinity)
+    })
+  }
+
   const body = lines.slice(start, end).join('\n')
 
   if (offset === 0) {
@@ -130,4 +251,27 @@ export function renderTranscript(
   }
 
   return `${body}\n\n${DIM}scroll offset: ${offset}${RESET}`
+}
+
+export function extractSelectedText(
+  entries: TranscriptEntry[],
+  selection: TranscriptSelection,
+): string {
+  const lines = renderTranscriptLines(entries)
+  const { startLine, startCol, endLine, endCol } = selection
+
+  const result: string[] = []
+  for (let i = startLine; i <= endLine && i < lines.length; i++) {
+    const plainLine = stripAnsi(lines[i])
+    if (i === startLine && i === endLine) {
+      result.push(sliceByDisplayColumns(plainLine, startCol, endCol))
+    } else if (i === startLine) {
+      result.push(sliceByDisplayColumns(plainLine, startCol, Infinity))
+    } else if (i === endLine) {
+      result.push(sliceByDisplayColumns(plainLine, 0, endCol))
+    } else {
+      result.push(plainLine)
+    }
+  }
+  return result.join('\n')
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -17,6 +17,9 @@ export {
   renderToolPanel,
   renderTranscript,
   showCursor,
+  extractSelectedText,
+  renderTranscriptLines,
 } from './tui/index.js'
 
 export type { TranscriptEntry } from './tui/index.js'
+export type { TranscriptSelection } from './tui/index.js'

--- a/test/mouse-release-selection.test.ts
+++ b/test/mouse-release-selection.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { TranscriptSelection } from '../src/tui/transcript.ts'
+
+const ttyAppModulePromise = import('../src/tty-app.ts')
+
+describe('mouse release selection', () => {
+  it('keeps the current selection after mouse release', async () => {
+    const ttyAppModule = await ttyAppModulePromise
+    const keepSelectionAfterMouseRelease =
+      (ttyAppModule as { keepSelectionAfterMouseRelease?: (selection: TranscriptSelection | null) => TranscriptSelection | null })
+        .keepSelectionAfterMouseRelease
+
+    assert.equal(typeof keepSelectionAfterMouseRelease, 'function')
+
+    const selection: TranscriptSelection = {
+      startLine: 6,
+      startCol: 1,
+      endLine: 14,
+      endCol: 44,
+    }
+
+    assert.deepEqual(keepSelectionAfterMouseRelease!(selection), selection)
+  })
+
+  it('keeps null when there is no selection', async () => {
+    const ttyAppModule = await ttyAppModulePromise
+    const keepSelectionAfterMouseRelease =
+      (ttyAppModule as { keepSelectionAfterMouseRelease?: (selection: TranscriptSelection | null) => TranscriptSelection | null })
+        .keepSelectionAfterMouseRelease
+
+    assert.equal(typeof keepSelectionAfterMouseRelease, 'function')
+    assert.equal(keepSelectionAfterMouseRelease!(null), null)
+  })
+})

--- a/test/transcript-cjk-selection.test.ts
+++ b/test/transcript-cjk-selection.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  extractSelectedText,
+  renderTranscript,
+  type TranscriptEntry,
+  type TranscriptSelection,
+} from '../src/tui/transcript.ts'
+
+function stripAnsi(input: string): string {
+  return input.replace(/\[[\d;]*[A-Za-z]/g, '')
+}
+
+function withTerminalWidth<T>(columns: number, fn: () => T): T {
+  const original = process.stdout.columns
+  Object.defineProperty(process.stdout, 'columns', {
+    value: columns,
+    configurable: true,
+  })
+  try {
+    return fn()
+  } finally {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: original,
+      configurable: true,
+    })
+  }
+}
+
+describe('transcript CJK selection', () => {
+  it('highlights a single full-width CJK character by display column', () => {
+    const entries: TranscriptEntry[] = [
+      { id: 1, kind: 'assistant', body: '你A' },
+    ]
+    const selection: TranscriptSelection = {
+      startLine: 1,
+      startCol: 2,
+      endLine: 1,
+      endCol: 4,
+    }
+
+    const rendered = withTerminalWidth(60, () => renderTranscript(entries, 0, 10, selection))
+    const plain = stripAnsi(rendered)
+
+    assert.ok(plain.includes('  你A'))
+    assert.ok(rendered.includes('[7m你[0m'))
+  })
+
+  it('extracts a single full-width CJK character by display column', () => {
+    const entries: TranscriptEntry[] = [
+      { id: 1, kind: 'assistant', body: '你A' },
+    ]
+    const selection: TranscriptSelection = {
+      startLine: 1,
+      startCol: 2,
+      endLine: 1,
+      endCol: 4,
+    }
+
+    const selected = withTerminalWidth(60, () => extractSelectedText(entries, selection))
+
+    assert.equal(selected, '你')
+  })
+})

--- a/test/transcript-wrapping.test.ts
+++ b/test/transcript-wrapping.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  extractSelectedText,
+  getTranscriptMaxScrollOffset,
+  type TranscriptEntry,
+  type TranscriptSelection,
+} from '../src/tui/transcript.ts'
+
+function withTerminalWidth<T>(columns: number, fn: () => T): T {
+  const original = process.stdout.columns
+  Object.defineProperty(process.stdout, 'columns', {
+    value: columns,
+    configurable: true,
+  })
+  try {
+    return fn()
+  } finally {
+    Object.defineProperty(process.stdout, 'columns', {
+      value: original,
+      configurable: true,
+    })
+  }
+}
+
+function makeWrappedAssistantEntry(): TranscriptEntry[] {
+  const wrappedBody = `${'a'.repeat(166)}BCDEFG`
+  return [
+    {
+      id: 1,
+      kind: 'assistant',
+      body: wrappedBody,
+    },
+  ]
+}
+
+describe('transcript wrapping', () => {
+  it('counts wrapped visual rows when calculating scroll offset', () => {
+    const entries = makeWrappedAssistantEntry()
+
+    const offset = withTerminalWidth(60, () => getTranscriptMaxScrollOffset(entries, 4))
+
+    assert.equal(offset, 1)
+  })
+
+  it('extracts text from a wrapped continuation row', () => {
+    const entries = makeWrappedAssistantEntry()
+    const selection: TranscriptSelection = {
+      startLine: 4,
+      startCol: 0,
+      endLine: 4,
+      endCol: 6,
+    }
+
+    const selected = withTerminalWidth(60, () => extractSelectedText(entries, selection))
+
+    assert.equal(selected, 'BCDEFG')
+  })
+})
+

--- a/test/windows-clipboard-encoding.test.ts
+++ b/test/windows-clipboard-encoding.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+const ttyAppModulePromise = import('../src/tty-app.ts')
+
+describe('Windows clipboard encoding', () => {
+  it('encodes clipboard text as UTF-16LE with BOM on win32', async () => {
+    const ttyAppModule = await ttyAppModulePromise
+    const encodeClipboardTextForPlatform =
+      (ttyAppModule as {
+        encodeClipboardTextForPlatform?: (platform: NodeJS.Platform, text: string) => string | Buffer
+      }).encodeClipboardTextForPlatform
+
+    assert.equal(typeof encodeClipboardTextForPlatform, 'function')
+
+    const encoded = encodeClipboardTextForPlatform!('win32', '这是一个最小骨架版本。')
+
+    assert.ok(Buffer.isBuffer(encoded))
+    assert.equal(encoded[0], 0xff)
+    assert.equal(encoded[1], 0xfe)
+    assert.equal(encoded.subarray(2).toString('utf16le'), '这是一个最小骨架版本。')
+  })
+})


### PR DESCRIPTION
## Summary
  Adds mouse support to the TUI transcript panel, enabling users to select and copy text with click-drag-release gestures.
This is part of #13 
  ## Demo
<img width="1280" height="720" alt="mouse_low_compressed" src="https://github.com/user-attachments/assets/4cebbe8c-9859-404b-80bc-51633a7a0915" />


  ## Changes
  - **Input parsing**: Extended `ParsedInputEvent` to recognize SGR mouse sequences (press/drag/release)
  - **Mouse tracking**: Enabled button-drag tracking mode (`1002`) in alternate screen
  - **Selection state**: Added selection coordinates and mouseDown state to `ScreenState`
  - **Visual feedback**: Highlight selected text with reverse video (`\u001b[7m`)
  - **Clipboard integration**: Copy selected text to system clipboard on mouse release
    - Windows: UTF-16LE with BOM for correct Chinese character encoding
    - macOS: `pbcopy`
    - Linux: `xclip`
  - **Display-width handling**: Correctly handle full-width CJK characters in selection and extraction
  - **Visual wrapping**: Align transcript rendering with panel wrapping so mouse coordinates map to visible rows

  ## Testing
  Added regression tests:
  - `test/transcript-wrapping.test.ts` — scroll offset and text extraction from wrapped rows
  - `test/transcript-cjk-selection.test.ts` — full-width character selection by display column
  - `test/mouse-release-selection.test.ts` — selection persistence after mouse release
  - `test/windows-clipboard-encoding.test.ts` — Windows clipboard UTF-16LE encoding

`npm run check` pass
<img width="1020" height="111" alt="image" src="https://github.com/user-attachments/assets/36b89863-c20d-4217-b4eb-046ed52947c3" />

  ## Known Limitations & Future Work 
  - **Selection scope**: Currently limited to session feed panel only. Future work could extend to other UI regions (prompt panel, approval panel, etc.)
  - **Multi-line paste**: TUI input does not yet support pasting multi-line text into the prompt
  - I can continuously workon that.

  ## Notes
  - Selection is scoped to the session feed panel to keep changes minimal and focused
  - Highlight persists after mouse release until next interaction
  - Follows project principle: minimal, direct changes without heavy abstractions