### PR TITLE
fix: preserve multi-line paste in TUI prompt

### DIFF
--- a/src/tui/input-parser.ts
+++ b/src/tui/input-parser.ts
@@ -36,6 +36,10 @@ type ParseResult = {
   rest: string
 }
 
+function isMultilinePasteChunk(input: string): boolean {
+  return /[\r\n]/.test(input) && /[^\r\n]/.test(input)
+}
+
 const ESC = '\u001b'
 const CTRL_CHAR_TO_NAME: Record<string, string> = {
   '\u0001': 'a',
@@ -185,7 +189,9 @@ export function parseInputChunk(
   previousRest: string,
   chunk: Buffer | string,
 ): ParseResult {
-  const input = previousRest + String(chunk)
+  const chunkText = String(chunk)
+  const input = previousRest + chunkText
+  const treatNewlinesAsText = isMultilinePasteChunk(chunkText)
   const events: ParsedInputEvent[] = []
   let index = 0
 
@@ -214,7 +220,11 @@ export function parseInputChunk(
     if (!char) break
 
     if (char === '\r' || char === '\n') {
-      events.push({ kind: 'key', name: 'return', ctrl: false, meta: false })
+      if (treatNewlinesAsText) {
+        events.push({ kind: 'text', text: '\n', ctrl: false, meta: false })
+      } else {
+        events.push({ kind: 'key', name: 'return', ctrl: false, meta: false })
+      }
       if (
         (char === '\r' && remaining[1] === '\n') ||
         (char === '\n' && remaining[1] === '\r')

--- a/test/input-parser.test.ts
+++ b/test/input-parser.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseInputChunk } from '../src/tui/input-parser.js'
+
+describe('parseInputChunk multiline paste', () => {
+  it('does not emit submit keys for pasted newlines and preserves the full text', () => {
+    const pasted = 'test1\r\ntest2\r\ntest3\r\ntest4\r\ntest5'
+    const result = parseInputChunk('', pasted)
+
+    assert.equal(result.rest, '')
+    assert.equal(
+      result.events.some(
+        event => event.kind === 'key' && event.name === 'return',
+      ),
+      false,
+    )
+    assert.equal(
+      result.events
+        .filter((event): event is Extract<(typeof result.events)[number], { kind: 'text' }> =>
+          event.kind === 'text',
+        )
+        .map(event => event.text)
+        .join(''),
+      'test1\ntest2\ntest3\ntest4\ntest5',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
  Fix multi-line paste handling in the TUI prompt.

  Previously, pasting multi-line text could submit the first line immediately, instead of keeping the full pasted content in the input box.

  Closes #16

  ## Changes
  - detect multi-line pasted input in `src/tui/input-parser.ts`
  - treat pasted newlines as text instead of submit keys
  - keep normal Enter submission behavior unchanged
  - add a regression test for multi-line paste parsing

  ## Notes
  This stays lightweight and local to input parsing.
  It does not add new dependencies or change the overall TUI interaction model.

  ## Verification
  - `npx tsx --test test/input-parser.test.ts`
  - `npm run check`

  ## Reproduction
  Paste the following into the TUI prompt:

  ```text
  test1
  test2
  test3
  test4
  test5
```
  Before:
  - test1 is submitted immediately
  - the pasted content does not remain intact in the prompt

  After:
  - the full pasted text stays in the prompt
  - nothing is submitted until Enter is pressed explicitly

## Demo
<img width="1280" height="720" alt="copy_issue_fix" src="https://github.com/user-attachments/assets/262345c8-6d4f-41e4-8a8b-738ad9ecb9a7" />

 Closes #16