### PR TITLE
Add deterministic snip compact for middle-history context reduction

### DIFF
--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -9,6 +9,10 @@ import type {
 import type { PermissionManager } from './permissions.js'
 import { microcompact } from './compact/microcompact.js'
 import { autoCompact } from './compact/auto-compact.js'
+import {
+  snipCompactConversation,
+  type SnipCompactResult,
+} from './compact/snipCompact.js'
 import { computeContextStats } from './utils/token-estimator.js'
 import {
   applyToolResultBudget,
@@ -111,7 +115,8 @@ export async function runAgentTurn(args: {
   onToolResult?: (toolName: string, output: string, isError: boolean) => void
   onAssistantMessage?: (content: string) => void
   onProgressMessage?: (content: string) => void
-  onAutoCompact?: (result: CompressionResult) => void
+  onAutoCompact?: (result: CompressionResult) => void | Promise<void>
+  onSnipCompact?: (result: SnipCompactResult) => void | Promise<void>
   onContextStats?: (stats: import('./utils/token-estimator.js').ContextStats) => void
   contentReplacementState?: ContentReplacementState
 }): Promise<ChatMessage[]> {
@@ -122,6 +127,7 @@ export async function runAgentTurn(args: {
   let recoverableThinkingRetryCount = 0
   let toolErrorCount = 0
   let sawToolResultThisTurn = false
+  let snippedThisTurn = false
   const contentReplacementState =
     args.contentReplacementState ?? createContentReplacementState()
 
@@ -147,22 +153,45 @@ export async function runAgentTurn(args: {
   }
 
   for (let step = 0; maxSteps == null || step < maxSteps; step++) {
-    // Microcompact: lightweight tool_result cleanup on every step
+    let latestStats: import('./utils/token-estimator.js').ContextStats | null = null
+
     if (modelName) {
+      latestStats = computeContextStats(messages, modelName)
+
+      if (!snippedThisTurn) {
+        const snipResult = await snipCompactConversation({
+          messages,
+          contextStats: latestStats,
+          modelContextWindow: latestStats.effectiveInput,
+        })
+        if (snipResult.didSnip) {
+          messages = snipResult.messages
+          snippedThisTurn = true
+          await args.onSnipCompact?.(snipResult)
+          latestStats = computeContextStats(messages, modelName)
+          args.onContextStats?.(latestStats)
+        }
+      }
+
+      const beforeMicrocompact = messages
       messages = microcompact(messages, modelName)
+      if (messages !== beforeMicrocompact) {
+        latestStats = computeContextStats(messages, modelName)
+        args.onContextStats?.(latestStats)
+      }
     }
 
     // AutoCompact: LLM-based compression when context is critical (first step only)
     if (step === 0 && modelName) {
-      const stats = computeContextStats(messages, modelName)
-      args.onContextStats?.(stats)
-      if (stats.warningLevel === 'critical' || stats.warningLevel === 'blocked') {
+      latestStats = latestStats ?? computeContextStats(messages, modelName)
+      args.onContextStats?.(latestStats)
+      if (latestStats.warningLevel === 'critical' || latestStats.warningLevel === 'blocked') {
         const result = await autoCompact(messages, modelName, args.model)
         if (result) {
           messages = result.messages
-          args.onAutoCompact?.(result)
-          const updatedStats = computeContextStats(messages, modelName)
-          args.onContextStats?.(updatedStats)
+          await args.onAutoCompact?.(result)
+          latestStats = computeContextStats(messages, modelName)
+          args.onContextStats?.(latestStats)
         }
       }
     }

--- a/src/anthropic-adapter.ts
+++ b/src/anthropic-adapter.ts
@@ -9,6 +9,7 @@ import type {
 } from './types.js'
 import type { RuntimeConfig } from './config.js'
 import { resolveMaxOutputTokens } from './utils/context.js'
+import { buildAnthropicSnipBoundaryText } from './compact/snipCompact.js'
 
 const DEFAULT_MAX_RETRIES = 4
 const BASE_RETRY_DELAY_MS = 500
@@ -278,6 +279,13 @@ function toAnthropicMessages(messages: ChatMessage[]): {
     if (message.role === 'context_summary') {
       pushAnthropicMessage(converted, 'user', toTextBlock(
         `[Context Summary from earlier conversation]\n${message.content}`,
+      ))
+      continue
+    }
+
+    if (message.role === 'snip_boundary') {
+      pushAnthropicMessage(converted, 'user', toTextBlock(
+        buildAnthropicSnipBoundaryText(),
       ))
       continue
     }

--- a/src/cli-commands.ts
+++ b/src/cli-commands.ts
@@ -130,6 +130,11 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     usage: '/compact',
     description: 'Compress conversation context to free up context window space.',
   },
+  {
+    name: '/snip',
+    usage: '/snip',
+    description: 'Remove a safe middle segment of conversation context without calling the model.',
+  },
 ]
 
 export function formatSlashCommands(): string {

--- a/src/compact/compact.ts
+++ b/src/compact/compact.ts
@@ -111,6 +111,9 @@ function messagesToText(messages: ChatMessage[]): string {
       case 'context_summary':
         parts.push(`[Previous Summary]: ${msg.content}`)
         break
+      case 'snip_boundary':
+        parts.push(`[Snipped Context Boundary]: ${msg.content}`)
+        break
       default:
         break
     }

--- a/src/compact/constants.ts
+++ b/src/compact/constants.ts
@@ -4,6 +4,12 @@ export const THRESHOLDS = {
   BLOCKED_UTILIZATION: 0.95,
 } as const
 
+export const SNIP_COMPACT_THRESHOLD = 0.70
+export const SNIP_TARGET_USAGE = 0.60
+export const SNIP_MIN_MESSAGES_TO_REMOVE = 6
+export const SNIP_KEEP_RECENT_MESSAGES = 12
+export const SNIP_MIN_TOKENS_TO_FREE = 2_000
+
 export const RETENTION = {
   KEEP_RECENT_TOOL_RESULTS: 3,
   MIN_KEEP_MESSAGES: 6,

--- a/src/compact/snipCompact.ts
+++ b/src/compact/snipCompact.ts
@@ -1,0 +1,499 @@
+import type { ChatMessage } from '../types.js'
+import type { ContextStats } from '../utils/token-estimator.js'
+import {
+  estimateMessagesTokens,
+  markProviderUsageStale,
+  tokenCountWithEstimation,
+} from '../utils/token-estimator.js'
+import {
+  SNIP_COMPACT_THRESHOLD,
+  SNIP_KEEP_RECENT_MESSAGES,
+  SNIP_MIN_MESSAGES_TO_REMOVE,
+  SNIP_MIN_TOKENS_TO_FREE,
+  SNIP_TARGET_USAGE,
+} from './constants.js'
+
+export type LoggerLike = {
+  debug?: (message: string) => void
+  info?: (message: string) => void
+  warn?: (message: string) => void
+  error?: (message: string) => void
+}
+
+export interface SnipCompactResult {
+  messages: ChatMessage[]
+  didSnip: boolean
+  tokensBefore: number
+  tokensAfter: number
+  tokensFreed: number
+  removedMessageIds: string[]
+  boundaryMessage?: ChatMessage
+  reason?: string
+}
+
+type MessageGroup = {
+  start: number
+  end: number
+  messages: ChatMessage[]
+  tokens: number
+  protected: boolean
+  reasons: string[]
+}
+
+type SafeRun = {
+  groups: MessageGroup[]
+  start: number
+  end: number
+  messagesCount: number
+  tokens: number
+}
+
+const PROTECTED_TOOL_NAMES = new Set([
+  'edit_file',
+  'modify_file',
+  'patch_file',
+  'write_file',
+  'apply_patch',
+])
+
+const ERROR_MARKERS = [
+  'error',
+  'failed',
+  'failure',
+  'exception',
+  'traceback',
+  'permission denied',
+]
+
+function noSnipResult(
+  messages: ChatMessage[],
+  tokensBefore: number,
+  reason: string,
+): SnipCompactResult {
+  return {
+    messages,
+    didSnip: false,
+    tokensBefore,
+    tokensAfter: tokensBefore,
+    tokensFreed: 0,
+    removedMessageIds: [],
+    reason,
+  }
+}
+
+function messageId(message: ChatMessage, index: number): string {
+  return message.id ?? `message-${index}`
+}
+
+function isBoundaryMessage(message: ChatMessage): boolean {
+  return (
+    message.role === 'system' ||
+    message.role === 'context_summary' ||
+    message.role === 'snip_boundary'
+  )
+}
+
+function isProtectedToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase()
+  return (
+    PROTECTED_TOOL_NAMES.has(normalized) ||
+    normalized.includes('patch') ||
+    normalized.includes('write') ||
+    normalized.includes('edit') ||
+    normalized.includes('modify')
+  )
+}
+
+function toolResultLooksImportantError(message: Extract<ChatMessage, {
+  role: 'tool_result'
+}>): boolean {
+  if (message.isError) return true
+  const content = message.content.toLowerCase()
+  return ERROR_MARKERS.some(marker => content.includes(marker))
+}
+
+function messageTextLooksImportantError(message: ChatMessage): boolean {
+  if (
+    message.role !== 'user' &&
+    message.role !== 'assistant' &&
+    message.role !== 'assistant_progress' &&
+    message.role !== 'context_summary' &&
+    message.role !== 'snip_boundary'
+  ) {
+    return false
+  }
+  const content = message.content.toLowerCase()
+  return ERROR_MARKERS.some(marker => content.includes(marker))
+}
+
+function groupHasProtectedTool(group: MessageGroup): boolean {
+  return group.messages.some(message => {
+    if (message.role === 'assistant_tool_call') {
+      return isProtectedToolName(message.toolName)
+    }
+    if (message.role === 'tool_result') {
+      return isProtectedToolName(message.toolName)
+    }
+    return false
+  })
+}
+
+function groupHasImportantError(group: MessageGroup): boolean {
+  return group.messages.some(message => (
+    messageTextLooksImportantError(message) ||
+    (message.role === 'tool_result' && toolResultLooksImportantError(message))
+  ))
+}
+
+function buildMessageGroups(messages: ChatMessage[]): MessageGroup[] {
+  const groups: MessageGroup[] = []
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+
+    if (message.role === 'assistant_tool_call') {
+      const next = messages[i + 1]
+      const groupedMessages =
+        next?.role === 'tool_result' && next.toolUseId === message.toolUseId
+          ? [message, next]
+          : [message]
+      groups.push({
+        start: i,
+        end: i + groupedMessages.length,
+        messages: groupedMessages,
+        tokens: estimateMessagesTokens(groupedMessages),
+        protected: groupedMessages.length === 1,
+        reasons: groupedMessages.length === 1 ? ['unclosed_tool_call'] : [],
+      })
+      i += groupedMessages.length - 1
+      continue
+    }
+
+    if (message.role === 'tool_result') {
+      groups.push({
+        start: i,
+        end: i + 1,
+        messages: [message],
+        tokens: estimateMessagesTokens([message]),
+        protected: true,
+        reasons: ['orphan_tool_result'],
+      })
+      continue
+    }
+
+    groups.push({
+      start: i,
+      end: i + 1,
+      messages: [message],
+      tokens: estimateMessagesTokens([message]),
+      protected: false,
+      reasons: [],
+    })
+  }
+
+  return groups
+}
+
+function addProtectedReason(group: MessageGroup, reason: string): void {
+  group.protected = true
+  if (!group.reasons.includes(reason)) {
+    group.reasons.push(reason)
+  }
+}
+
+function protectNearbyGroups(groups: MessageGroup[], index: number, reason: string): void {
+  for (let i = Math.max(0, index - 1); i <= Math.min(groups.length - 1, index + 1); i++) {
+    addProtectedReason(groups[i]!, reason)
+  }
+}
+
+function markProtectedGroups(
+  groups: MessageGroup[],
+  candidateStart: number,
+  candidateEnd: number,
+): void {
+  for (const group of groups) {
+    if (group.start < candidateStart || group.end > candidateEnd) {
+      addProtectedReason(group, 'outside_candidate_range')
+      continue
+    }
+
+    if (group.messages.some(isBoundaryMessage)) {
+      addProtectedReason(group, 'boundary_message')
+    }
+  }
+
+  for (let i = 0; i < groups.length; i++) {
+    const group = groups[i]!
+    if (groupHasProtectedTool(group)) {
+      protectNearbyGroups(groups, i, 'near_file_edit')
+    }
+    if (groupHasImportantError(group)) {
+      protectNearbyGroups(groups, i, 'near_important_error')
+    }
+  }
+}
+
+function findCandidateRange(messages: ChatMessage[]): {
+  start: number
+  end: number
+  reason?: string
+} {
+  if (messages.length <= SNIP_KEEP_RECENT_MESSAGES + SNIP_MIN_MESSAGES_TO_REMOVE) {
+    return { start: 0, end: 0, reason: 'too_few_messages' }
+  }
+
+  const keepRecentStart = Math.max(0, messages.length - SNIP_KEEP_RECENT_MESSAGES)
+  let lastUserIndex = -1
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === 'user') {
+      lastUserIndex = i
+      break
+    }
+  }
+
+  const end = Math.min(
+    keepRecentStart,
+    lastUserIndex >= 0 ? lastUserIndex : messages.length,
+  )
+  if (end <= 0) {
+    return { start: 0, end: 0, reason: 'no_middle_range' }
+  }
+
+  let start = 0
+  for (let i = 0; i < end; i++) {
+    if (isBoundaryMessage(messages[i]!)) {
+      start = i + 1
+    }
+  }
+
+  if (end - start < SNIP_MIN_MESSAGES_TO_REMOVE) {
+    return { start, end, reason: 'candidate_range_too_small' }
+  }
+
+  return { start, end }
+}
+
+function findSafeRuns(groups: MessageGroup[]): SafeRun[] {
+  const runs: SafeRun[] = []
+  let current: MessageGroup[] = []
+
+  const flush = () => {
+    if (current.length === 0) return
+    const first = current[0]!
+    const last = current[current.length - 1]!
+    runs.push({
+      groups: current,
+      start: first.start,
+      end: last.end,
+      messagesCount: last.end - first.start,
+      tokens: current.reduce((sum, group) => sum + group.tokens, 0),
+    })
+    current = []
+  }
+
+  for (const group of groups) {
+    if (group.protected) {
+      flush()
+      continue
+    }
+    current.push(group)
+  }
+  flush()
+
+  return runs
+}
+
+function compareRuns(a: SafeRun, b: SafeRun): number {
+  const tokenDelta = b.tokens - a.tokens
+  if (tokenDelta !== 0) return tokenDelta
+  const messageDelta = b.messagesCount - a.messagesCount
+  if (messageDelta !== 0) return messageDelta
+  return a.start - b.start
+}
+
+function selectDeletionFromRun(run: SafeRun, desiredTokensToFree: number): {
+  start: number
+  end: number
+  tokens: number
+  messagesCount: number
+} {
+  let endGroupIndex = -1
+  let tokens = 0
+  let messagesCount = 0
+
+  for (let i = 0; i < run.groups.length; i++) {
+    const group = run.groups[i]!
+    tokens += group.tokens
+    messagesCount = group.end - run.start
+    endGroupIndex = i
+
+    if (
+      tokens >= desiredTokensToFree &&
+      messagesCount >= SNIP_MIN_MESSAGES_TO_REMOVE
+    ) {
+      break
+    }
+  }
+
+  const endGroup = run.groups[Math.max(0, endGroupIndex)]!
+  return {
+    start: run.start,
+    end: endGroup.end,
+    tokens,
+    messagesCount,
+  }
+}
+
+export function buildSnipBoundaryContent(args: {
+  removedCount: number
+  tokensFreed: number
+}): string {
+  return [
+    '[Snipped earlier conversation segment]',
+    '',
+    'A middle portion of the earlier conversation was removed to preserve context space.',
+    '',
+    'Removed range:',
+    `- messages: ${args.removedCount}`,
+    `- approximate tokens freed: ${Math.max(0, Math.round(args.tokensFreed))}`,
+    '',
+    'The recent conversation and active task context are preserved.',
+  ].join('\n')
+}
+
+export function buildAnthropicSnipBoundaryText(): string {
+  return [
+    '[Snipped earlier conversation segment]',
+    '',
+    'A middle portion of the earlier conversation was removed to preserve context space.',
+    'The recent conversation and active task context are preserved.',
+  ].join('\n')
+}
+
+function buildBoundaryMessage(args: {
+  removedMessageIds: string[]
+  removedCount: number
+  tokensFreed: number
+}): Extract<ChatMessage, { role: 'snip_boundary' }> {
+  const timestamp = Date.now()
+  const firstRemoved = args.removedMessageIds[0] ?? 'none'
+  return {
+    id: `snip-${timestamp}-${firstRemoved}`,
+    role: 'snip_boundary',
+    content: buildSnipBoundaryContent({
+      removedCount: args.removedCount,
+      tokensFreed: args.tokensFreed,
+    }),
+    removedMessageIds: args.removedMessageIds,
+    removedCount: args.removedCount,
+    tokensFreed: args.tokensFreed,
+    timestamp,
+  }
+}
+
+function markRetainedUsageStale(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map(message => markProviderUsageStale(
+    message,
+    'conversation was snip-compacted after this provider usage was recorded',
+  ))
+}
+
+export async function snipCompactConversation(params: {
+  messages: ChatMessage[]
+  contextStats: ContextStats
+  modelContextWindow: number
+  logger?: LoggerLike
+}): Promise<SnipCompactResult> {
+  const triggerTokens = params.contextStats.totalTokens
+  const tokensBefore = estimateMessagesTokens(params.messages)
+  const effectiveInput =
+    params.contextStats.effectiveInput > 0
+      ? params.contextStats.effectiveInput
+      : params.modelContextWindow
+  const utilization =
+    effectiveInput > 0 ? triggerTokens / effectiveInput : params.contextStats.utilization
+
+  if (utilization < SNIP_COMPACT_THRESHOLD) {
+    return noSnipResult(params.messages, tokensBefore, 'below_threshold')
+  }
+
+  const range = findCandidateRange(params.messages)
+  if (range.reason) {
+    params.logger?.debug?.(`[snip-compact] ${range.reason}`)
+    return noSnipResult(params.messages, tokensBefore, range.reason)
+  }
+
+  const groups = buildMessageGroups(params.messages)
+  markProtectedGroups(groups, range.start, range.end)
+
+  const safeRuns = findSafeRuns(groups)
+    .filter(run => (
+      run.messagesCount >= SNIP_MIN_MESSAGES_TO_REMOVE &&
+      run.tokens >= SNIP_MIN_TOKENS_TO_FREE
+    ))
+    .sort(compareRuns)
+
+  const bestRun = safeRuns[0]
+  if (!bestRun) {
+    return noSnipResult(params.messages, tokensBefore, 'no_safe_interval')
+  }
+
+  const targetTokens = Math.floor(effectiveInput * SNIP_TARGET_USAGE)
+  const desiredTokensToFree = Math.max(
+    SNIP_MIN_TOKENS_TO_FREE,
+    triggerTokens - targetTokens,
+  )
+  const deletion = selectDeletionFromRun(bestRun, desiredTokensToFree)
+  if (deletion.messagesCount < SNIP_MIN_MESSAGES_TO_REMOVE) {
+    return noSnipResult(params.messages, tokensBefore, 'below_min_messages')
+  }
+
+  const removedMessages = params.messages.slice(deletion.start, deletion.end)
+  const removedMessageIds = removedMessages.map((message, offset) => (
+    messageId(message, deletion.start + offset)
+  ))
+  const boundaryMessage = buildBoundaryMessage({
+    removedMessageIds,
+    removedCount: removedMessages.length,
+    tokensFreed: deletion.tokens,
+  })
+  const boundaryTokens = estimateMessagesTokens([boundaryMessage])
+  const estimatedTokensFreed = Math.max(0, deletion.tokens - boundaryTokens)
+
+  if (estimatedTokensFreed < SNIP_MIN_TOKENS_TO_FREE) {
+    return noSnipResult(params.messages, tokensBefore, 'below_min_tokens')
+  }
+
+  const messagesAfterSnip = markRetainedUsageStale([
+    ...params.messages.slice(0, deletion.start),
+    {
+      ...boundaryMessage,
+      content: buildSnipBoundaryContent({
+        removedCount: removedMessages.length,
+        tokensFreed: estimatedTokensFreed,
+      }),
+      tokensFreed: estimatedTokensFreed,
+    },
+    ...params.messages.slice(deletion.end),
+  ])
+  const tokensAfter = tokenCountWithEstimation(messagesAfterSnip).totalTokens
+  const tokensFreed = Math.max(0, tokensBefore - tokensAfter)
+
+  if (tokensAfter >= tokensBefore) {
+    return noSnipResult(params.messages, tokensBefore, 'no_token_reduction')
+  }
+
+  const finalBoundaryMessage = messagesAfterSnip[deletion.start]
+
+  return {
+    messages: messagesAfterSnip,
+    didSnip: true,
+    tokensBefore,
+    tokensAfter,
+    tokensFreed,
+    removedMessageIds,
+    boundaryMessage: finalBoundaryMessage,
+    reason: 'snipped_safe_middle_interval',
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -196,6 +196,7 @@ async function main(): Promise<void> {
           messages,
           cwd,
           permissions,
+          modelName: runtime?.model ?? '',
           contentReplacementState,
         })
       } catch (error) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,16 @@ import type { ChatMessage } from './types.js'
 
 const MAX_TITLE_LENGTH = 60
 
-type EventType = 'system' | 'user' | 'assistant' | 'thinking' | 'progress' | 'tool_call' | 'tool_result' | 'summary' | 'compact_boundary' | 'rename'
+type EventType = 'system' | 'user' | 'assistant' | 'thinking' | 'progress' | 'tool_call' | 'tool_result' | 'summary' | 'compact_boundary' | 'snip_boundary' | 'rename'
+
+export type SnipBoundaryMetadata = {
+  type: 'snip_boundary'
+  removedMessageIds: string[]
+  removedCount: number
+  tokensFreed: number
+  timestamp: string
+  createdAt: string
+}
 
 type SessionEvent = {
   type: EventType
@@ -27,6 +36,7 @@ type SessionEvent = {
   logicalParentUuid?: string | null
   subtype?: string
   compactMetadata?: { trigger: string; preTokens: number; postTokens: number }
+  snipMetadata?: SnipBoundaryMetadata
   title?: string
 }
 
@@ -52,19 +62,37 @@ function roleToType(role: string): EventType {
     case 'assistant_tool_call': return 'tool_call'
     case 'tool_result': return 'tool_result'
     case 'context_summary': return 'summary'
+    case 'snip_boundary': return 'snip_boundary'
     default: return 'user'
   }
 }
 
+function ensureMessageId(message: ChatMessage): string {
+  if (message.id) return message.id
+  message.id = randomUUID()
+  return message.id
+}
+
 function wrapEvent(message: ChatMessage, sessionId: string, cwd: string, parentUuid: string | null): string {
+  const uuid = ensureMessageId(message)
   const event: SessionEvent = {
     type: roleToType(message.role),
     message,
-    uuid: randomUUID(),
+    uuid,
     timestamp: new Date().toISOString(),
     sessionId,
     cwd,
     parentUuid,
+  }
+  if (message.role === 'snip_boundary') {
+    event.snipMetadata = {
+      type: 'snip_boundary',
+      removedMessageIds: message.removedMessageIds,
+      removedCount: message.removedCount,
+      tokensFreed: message.tokensFreed,
+      timestamp: event.timestamp,
+      createdAt: event.timestamp,
+    }
   }
   return JSON.stringify(event)
 }
@@ -78,8 +106,58 @@ function parseEvent(line: string): SessionEvent | null {
 }
 
 function unwrapMessage(event: SessionEvent): ChatMessage | null {
-  if (event.message) return event.message as ChatMessage
+  if (event.message) {
+    return {
+      ...event.message,
+      id: event.uuid,
+    } as ChatMessage
+  }
   return null
+}
+
+function reconstructSnippedEvents(events: SessionEvent[]): SessionEvent[] {
+  const snipEvents = events.filter(event => (
+    event.type === 'snip_boundary' &&
+    event.snipMetadata &&
+    event.snipMetadata.removedMessageIds.length > 0
+  ))
+
+  if (snipEvents.length === 0) {
+    return events
+  }
+
+  const removedIdToSnips = new Map<string, SessionEvent[]>()
+  for (const snip of snipEvents) {
+    for (const removedId of snip.snipMetadata!.removedMessageIds) {
+      const existing = removedIdToSnips.get(removedId) ?? []
+      existing.push(snip)
+      removedIdToSnips.set(removedId, existing)
+    }
+  }
+
+  const insertedSnips = new Set<string>()
+  const result: SessionEvent[] = []
+
+  for (const event of events) {
+    if (event.type === 'snip_boundary') {
+      continue
+    }
+
+    const snipsForRemovedEvent = removedIdToSnips.get(event.uuid) ?? []
+    if (snipsForRemovedEvent.length > 0) {
+      for (const snip of snipsForRemovedEvent) {
+        if (!insertedSnips.has(snip.uuid)) {
+          result.push(snip)
+          insertedSnips.add(snip.uuid)
+        }
+      }
+      continue
+    }
+
+    result.push(event)
+  }
+
+  return result
 }
 
 function extractTitleFromEvents(lines: string[]): string | undefined {
@@ -115,18 +193,44 @@ async function readLastEventUuid(filePath: string): Promise<string | null> {
   }
 }
 
+async function readExistingEventUuids(filePath: string): Promise<Set<string>> {
+  try {
+    const content = await readFile(filePath, 'utf8')
+    const ids = new Set<string>()
+    for (const line of content.trim().split('\n').filter(Boolean)) {
+      const event = parseEvent(line)
+      if (event?.uuid) {
+        ids.add(event.uuid)
+      }
+    }
+    return ids
+  } catch {
+    return new Set()
+  }
+}
+
 export async function saveSession(
   cwd: string,
   sessionId: string,
   messages: ChatMessage[],
   alreadySavedCount: number = 0,
 ): Promise<void> {
-  const toSave = messages.slice(1).slice(alreadySavedCount)
-  if (toSave.length === 0) return
-
   const dir = projectDir(cwd)
   const filePath = sessionFilePath(cwd, sessionId)
   await mkdir(dir, { recursive: true })
+
+  const existingIds = await readExistingEventUuids(filePath)
+  const nonSystemMessages = messages.slice(1)
+  const toSave = nonSystemMessages.filter((message, index) => {
+    if (message.id && existingIds.has(message.id)) {
+      return false
+    }
+    if (message.id && !existingIds.has(message.id)) {
+      return true
+    }
+    return index >= alreadySavedCount
+  })
+  if (toSave.length === 0) return
 
   let parentUuid = await readLastEventUuid(filePath)
   const lines: string[] = []
@@ -139,6 +243,42 @@ export async function saveSession(
   await appendFile(filePath, lines.join('\n') + '\n', 'utf8')
 }
 
+export async function appendSnipBoundary(
+  cwd: string,
+  sessionId: string,
+  boundaryMessage: Extract<ChatMessage, { role: 'snip_boundary' }>,
+): Promise<void> {
+  const dir = projectDir(cwd)
+  const filePath = sessionFilePath(cwd, sessionId)
+  await mkdir(dir, { recursive: true })
+
+  const lastUuid = await readLastEventUuid(filePath)
+  const now = new Date().toISOString()
+  const uuid = ensureMessageId(boundaryMessage)
+
+  const event: SessionEvent = {
+    type: 'snip_boundary',
+    subtype: 'snip_boundary',
+    message: boundaryMessage,
+    uuid,
+    timestamp: now,
+    sessionId,
+    cwd,
+    parentUuid: null,
+    logicalParentUuid: lastUuid,
+    snipMetadata: {
+      type: 'snip_boundary',
+      removedMessageIds: boundaryMessage.removedMessageIds,
+      removedCount: boundaryMessage.removedCount,
+      tokensFreed: boundaryMessage.tokensFreed,
+      timestamp: now,
+      createdAt: now,
+    },
+  }
+
+  await appendFile(filePath, JSON.stringify(event) + '\n', 'utf8')
+}
+
 export async function appendCompactBoundary(
   cwd: string,
   sessionId: string,
@@ -146,6 +286,7 @@ export async function appendCompactBoundary(
   trigger: 'auto' | 'manual',
   preTokens: number,
   postTokens: number,
+  retainedMessages: ChatMessage[] = [],
 ): Promise<void> {
   const dir = projectDir(cwd)
   const filePath = sessionFilePath(cwd, sessionId)
@@ -176,7 +317,19 @@ export async function appendCompactBoundary(
     parentUuid: boundary.uuid,
   }
 
-  await appendFile(filePath, JSON.stringify(boundary) + '\n' + JSON.stringify(summary) + '\n', 'utf8')
+  const lines = [
+    JSON.stringify(boundary),
+    JSON.stringify(summary),
+  ]
+  let parentUuid = summary.uuid
+  for (const message of retainedMessages) {
+    const line = wrapEvent(message, sessionId, cwd, parentUuid)
+    const parsed = JSON.parse(line) as SessionEvent
+    parentUuid = parsed.uuid
+    lines.push(line)
+  }
+
+  await appendFile(filePath, lines.join('\n') + '\n', 'utf8')
 }
 
 export async function loadSession(
@@ -198,10 +351,14 @@ export async function loadSession(
     }
 
     const startLine = lastBoundaryIndex >= 0 ? lastBoundaryIndex + 1 : 0
-    const messages: ChatMessage[] = []
+    const activeEvents: SessionEvent[] = []
     for (let i = startLine; i < lines.length; i++) {
       const event = parseEvent(lines[i]!)
-      if (!event) continue
+      if (event) activeEvents.push(event)
+    }
+
+    const messages: ChatMessage[] = []
+    for (const event of reconstructSnippedEvents(activeEvents)) {
       const msg = unwrapMessage(event)
       if (msg) messages.push(msg)
     }
@@ -427,9 +584,13 @@ export async function loadTranscript(
     const lines = content.trim().split('\n').filter(Boolean)
     const entries: PersistedTranscriptEntry[] = []
 
-    for (const line of lines) {
-      const event = parseEvent(line)
-      if (!event) continue
+    const events = reconstructSnippedEvents(
+      lines
+        .map(line => parseEvent(line))
+        .filter((event): event is SessionEvent => Boolean(event)),
+    )
+
+    for (const event of events) {
 
       const msg = (event.message ?? {}) as Record<string, unknown>
 
@@ -461,6 +622,12 @@ export async function loadTranscript(
           entries.push({
             kind: 'assistant',
             body: `[Context compacted: ${event.compactMetadata?.preTokens ?? '?'} → ${event.compactMetadata?.postTokens ?? '?'} tokens]`,
+          })
+          break
+        case 'snip_boundary':
+          entries.push({
+            kind: 'assistant',
+            body: `[Snipped earlier context: removed ${event.snipMetadata?.removedCount ?? '?'} messages, freed ~${event.snipMetadata?.tokensFreed ?? '?'} tokens]`,
           })
           break
       }

--- a/src/tty-app.ts
+++ b/src/tty-app.ts
@@ -23,6 +23,7 @@ import {
   listSessions,
   renameSession,
   appendCompactBoundary,
+  appendSnipBoundary,
   loadTranscript,
   forkSession,
   cleanupExpiredSessions,
@@ -55,6 +56,7 @@ import type { ChatMessage, CompressionResult, ModelAdapter } from './types.js'
 import type { ContextStats } from './utils/token-estimator.js'
 import { computeContextStats } from './utils/token-estimator.js'
 import { manualCompact } from './compact/manual-compact.js'
+import { snipCompactConversation } from './compact/snipCompact.js'
 import {
   createContentReplacementState,
   type ContentReplacementState,
@@ -584,6 +586,12 @@ async function refreshSystemPrompt(args: TtyAppArgs): Promise<void> {
   }
 }
 
+function retainedMessagesAfterCompact(result: CompressionResult): ChatMessage[] {
+  return result.messages.filter(message => (
+    message.role !== 'system' && message !== result.summary
+  ))
+}
+
 async function executeToolShortcut(
   args: TtyAppArgs,
   state: ScreenState,
@@ -673,6 +681,11 @@ async function resumeSession(
           kind: 'assistant',
           body: `[Context summary: ${msg.compressedCount} messages compressed]`,
         })
+      } else if (msg.role === 'snip_boundary') {
+        pushTranscriptEntry(state, {
+          kind: 'assistant',
+          body: `Snipped earlier context: removed ${msg.removedCount} messages, freed ~${Math.round(msg.tokensFreed)} tokens.`,
+        })
       }
     }
   }
@@ -701,6 +714,42 @@ async function handleInput(
   if (!input) return false
   if (input === '/exit') return true
 
+  // /snip: deterministic middle-context removal without calling the model
+  if (input === '/snip') {
+    const model = args.runtime?.model ?? ''
+    const stats = computeContextStats(args.messages, model)
+    const result = await snipCompactConversation({
+      messages: args.messages,
+      contextStats: stats,
+      modelContextWindow: stats.effectiveInput,
+    })
+
+    if (!result.didSnip || result.boundaryMessage?.role !== 'snip_boundary') {
+      pushTranscriptEntry(state, {
+        kind: 'assistant',
+        body: 'Nothing safe to snip.',
+      })
+      return false
+    }
+
+    await appendSnipBoundary(args.cwd, args.sessionId, result.boundaryMessage)
+    args.messages.length = 0
+    args.messages.push(...result.messages)
+    args.alreadySavedCount = 0
+    state.contextStats = computeContextStats(args.messages, model)
+    state.compressionStatus = `snip saved ~${Math.round(result.tokensFreed)} tokens`
+    state.transcriptScrollOffset = 0
+    pushTranscriptEntry(state, {
+      kind: 'assistant',
+      body: `Snipped earlier context: removed ${result.removedMessageIds.length} messages, freed ~${Math.round(result.tokensFreed)} tokens.`,
+    })
+    setTimeout(() => {
+      state.compressionStatus = null
+      rerender()
+    }, 5000)
+    return false
+  }
+
   // /compact: manual context compression
   if (input === '/compact') {
     if (args.messages.length <= 2) {
@@ -726,7 +775,15 @@ async function handleInput(
       const result = await manualCompact(args.messages, args.model)
       if (result) {
         const summaryText = typeof result.summary.content === 'string' ? result.summary.content : ''
-        await appendCompactBoundary(args.cwd, args.sessionId, summaryText, 'manual', result.tokensBefore, result.tokensAfter)
+        await appendCompactBoundary(
+          args.cwd,
+          args.sessionId,
+          summaryText,
+          'manual',
+          result.tokensBefore,
+          result.tokensAfter,
+          retainedMessagesAfterCompact(result),
+        )
         args.messages.length = 0
         args.messages.push(...result.messages)
         args.alreadySavedCount = args.messages.length - 1
@@ -955,7 +1012,7 @@ async function handleInput(
         state.contextStats = stats
         rerender()
       },
-      onAutoCompact(result) {
+      async onAutoCompact(result) {
         const savedPct = Math.round((1 - result.tokensAfter / result.tokensBefore) * 100)
         const savedTokens = result.tokensBefore - result.tokensAfter
         state.compressionStatus = `ctx -${savedPct}% (saved ${savedTokens >= 1000 ? `${Math.round(savedTokens / 1000)}K` : savedTokens} tokens)`
@@ -964,8 +1021,32 @@ async function handleInput(
           body: `Context auto-compressed: ${result.removedCount} messages summarized.`,
         })
         const summaryText = typeof result.summary.content === 'string' ? result.summary.content : ''
-        void appendCompactBoundary(args.cwd, args.sessionId, summaryText, 'auto', result.tokensBefore, result.tokensAfter)
-        args.alreadySavedCount = 2 // boundary + summary events appended
+        await appendCompactBoundary(
+          args.cwd,
+          args.sessionId,
+          summaryText,
+          'auto',
+          result.tokensBefore,
+          result.tokensAfter,
+          retainedMessagesAfterCompact(result),
+        )
+        args.alreadySavedCount = result.messages.length - 1
+        state.transcriptScrollOffset = 0
+        setTimeout(() => {
+          state.compressionStatus = null
+          rerender()
+        }, 5000)
+      },
+      async onSnipCompact(result) {
+        if (result.boundaryMessage?.role === 'snip_boundary') {
+          await appendSnipBoundary(args.cwd, args.sessionId, result.boundaryMessage)
+        }
+        args.alreadySavedCount = 0
+        state.compressionStatus = `snip saved ~${Math.round(result.tokensFreed)} tokens`
+        pushTranscriptEntry(state, {
+          kind: 'assistant',
+          body: `Snipped earlier context: removed ${result.removedMessageIds.length} messages, freed ~${Math.round(result.tokensFreed)} tokens.`,
+        })
         state.transcriptScrollOffset = 0
         setTimeout(() => {
           state.compressionStatus = null

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,31 +16,43 @@ export type ProviderThinkingBlock = {
   [key: string]: unknown
 }
 
+export type MessageIdentity = {
+  id?: string
+}
+
 export type ChatMessage =
-  | { role: 'system'; content: string }
-  | { role: 'user'; content: string }
-  | { role: 'assistant_thinking'; blocks: ProviderThinkingBlock[] }
-  | ({ role: 'assistant'; content: string } & ProviderUsageMetadata)
-  | ({ role: 'assistant_progress'; content: string } & ProviderUsageMetadata)
+  | ({ role: 'system'; content: string } & MessageIdentity)
+  | ({ role: 'user'; content: string } & MessageIdentity)
+  | ({ role: 'assistant_thinking'; blocks: ProviderThinkingBlock[] } & MessageIdentity)
+  | ({ role: 'assistant'; content: string } & ProviderUsageMetadata & MessageIdentity)
+  | ({ role: 'assistant_progress'; content: string } & ProviderUsageMetadata & MessageIdentity)
   | ({
       role: 'assistant_tool_call'
       toolUseId: string
       toolName: string
       input: unknown
-    } & ProviderUsageMetadata)
-  | {
+    } & ProviderUsageMetadata & MessageIdentity)
+  | ({
       role: 'tool_result'
       toolUseId: string
       toolName: string
       content: string
       isError: boolean
-    }
-  | {
+    } & MessageIdentity)
+  | ({
       role: 'context_summary'
       content: string
       compressedCount: number
       timestamp: number
-    }
+    } & MessageIdentity)
+  | ({
+      role: 'snip_boundary'
+      content: string
+      removedMessageIds: string[]
+      removedCount: number
+      tokensFreed: number
+      timestamp: number
+    } & MessageIdentity)
 
 export type ToolCall = {
   id: string

--- a/src/utils/token-estimator.ts
+++ b/src/utils/token-estimator.ts
@@ -40,6 +40,7 @@ const CHARS_PER_TOKEN: Record<string, number> = {
   assistant_tool_call: 2.5,
   tool_result: 2.0,
   context_summary: 3.5,
+  snip_boundary: 3.5,
 }
 
 const CLEAR_MARKER = '[Output cleared for context space]'
@@ -66,6 +67,8 @@ function messageContentLength(message: ChatMessage): number {
     case 'tool_result':
       return message.content.length
     case 'context_summary':
+      return message.content.length
+    case 'snip_boundary':
       return message.content.length
     default:
       return 0

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -10,13 +10,21 @@ import {
   listSessions,
   renameSession,
   appendCompactBoundary,
+  appendSnipBoundary,
   loadTranscript,
   forkSession,
   cleanupExpiredSessions,
   listAllProjects,
 } from '../src/session.js'
 import { MINI_CODE_PROJECTS_DIR } from '../src/config.js'
-import type { ChatMessage } from '../src/types.js'
+import type { AgentStep, ChatMessage, ModelAdapter } from '../src/types.js'
+import type { ContextStats } from '../src/utils/token-estimator.js'
+import {
+  estimateMessagesTokens,
+  tokenCountWithEstimation,
+} from '../src/utils/token-estimator.js'
+import { snipCompactConversation } from '../src/compact/snipCompact.js'
+import { compactConversation } from '../src/compact/compact.js'
 
 const testDir = path.join(os.tmpdir(), 'minicode-session-test')
 
@@ -33,6 +41,60 @@ function makeMessages(count: number): ChatMessage[] {
 
 function projectDirName(cwd: string): string {
   return cwd.replace(/[/\\:]+/g, '-').replace(/^-+/, '')
+}
+
+function contextStats(messages: ChatMessage[], effectiveInput = 20_000): ContextStats {
+  const accounting = tokenCountWithEstimation(messages)
+  const utilization = accounting.totalTokens / effectiveInput
+  return {
+    estimatedTokens: estimateMessagesTokens(messages),
+    totalTokens: accounting.totalTokens,
+    providerUsageTokens: accounting.providerUsageTokens,
+    contextWindow: effectiveInput,
+    effectiveInput,
+    utilization,
+    warningLevel:
+      utilization >= 0.95
+        ? 'blocked'
+        : utilization >= 0.85
+          ? 'critical'
+          : utilization >= 0.50
+            ? 'warning'
+            : 'normal',
+    accounting,
+  }
+}
+
+function assertNoToolOrphans(messages: ChatMessage[]): void {
+  const calls = new Set(
+    messages
+      .filter((message): message is Extract<ChatMessage, { role: 'assistant_tool_call' }> => (
+        message.role === 'assistant_tool_call'
+      ))
+      .map(message => message.toolUseId),
+  )
+  const results = new Set(
+    messages
+      .filter((message): message is Extract<ChatMessage, { role: 'tool_result' }> => (
+        message.role === 'tool_result'
+      ))
+      .map(message => message.toolUseId),
+  )
+
+  for (const id of calls) {
+    assert.ok(results.has(id), `tool call ${id} should keep its result`)
+  }
+  for (const id of results) {
+    assert.ok(calls.has(id), `tool result ${id} should keep its call`)
+  }
+}
+
+function retainedMessagesAfterCompact(
+  result: NonNullable<Awaited<ReturnType<typeof compactConversation>>>,
+): ChatMessage[] {
+  return result.messages.filter(message => (
+    message.role !== 'system' && message !== result.summary
+  ))
 }
 
 async function cleanupAll() {
@@ -289,6 +351,143 @@ describe('session persistence', () => {
     assert.equal(loaded![0].content, 'Summary of 4 messages')
     assert.equal(loaded![1].content, 'after compact user')
     assert.equal(loaded![2].content, 'after compact assistant')
+  })
+
+  it('loadSession filters messages removed by snip_boundary metadata', async () => {
+    const cwd = path.join(testDir, 'snip-load')
+    await saveSession(cwd, 'snip001', makeMessages(8), 0)
+
+    const beforeSnip = await loadSession(cwd, 'snip001')
+    assert.ok(beforeSnip)
+    const removed = beforeSnip!.slice(2, 8)
+    const removedIds = removed.map(message => message.id!).filter(Boolean)
+    assert.ok(removedIds.length >= 6)
+
+    await appendSnipBoundary(cwd, 'snip001', {
+      role: 'snip_boundary',
+      content: '[Snipped earlier conversation segment]',
+      removedMessageIds: removedIds,
+      removedCount: removedIds.length,
+      tokensFreed: 2_500,
+      timestamp: 12345,
+    })
+
+    const pdir = path.join(MINI_CODE_PROJECTS_DIR, projectDirName(cwd))
+    const content = await readFile(path.join(pdir, 'snip001.jsonl'), 'utf8')
+    const snipEvent = content
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line))
+      .find(event => event.type === 'snip_boundary')
+    assert.ok(snipEvent)
+    assert.deepEqual(snipEvent.snipMetadata.removedMessageIds, removedIds)
+    assert.equal(snipEvent.snipMetadata.removedCount, removedIds.length)
+    assert.equal(snipEvent.snipMetadata.tokensFreed, 2_500)
+    assert.equal(typeof snipEvent.snipMetadata.timestamp, 'string')
+
+    const loaded = await loadSession(cwd, 'snip001')
+    assert.ok(loaded)
+    const loadedIds = new Set(loaded!.map(message => message.id))
+    for (const removedId of removedIds) {
+      assert.equal(loadedIds.has(removedId), false)
+    }
+    const boundaryIndex = loaded!.findIndex(message => message.role === 'snip_boundary')
+    assert.ok(boundaryIndex >= 0)
+    assert.equal(loaded![boundaryIndex]!.role, 'snip_boundary')
+  })
+
+  it('restores correctly across snip, save, load, compact, save, and load', async () => {
+    const cwd = path.join(testDir, 'snip-compact-load')
+    const sessionId = 'snipcmp1'
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Opening task' },
+    ]
+    for (let i = 0; i < 24; i++) {
+      messages.push(
+        { role: 'assistant', content: `Old assistant ${i}: ${'a'.repeat(2_000)}` },
+        { role: 'user', content: `Old user ${i}: ${'b'.repeat(2_000)}` },
+      )
+    }
+    messages.push(
+      { role: 'assistant', content: 'Recent setup before tool' },
+      { role: 'assistant_tool_call', toolUseId: 'tail-tool', toolName: 'read_file', input: { path: 'tail.ts' } },
+      { role: 'tool_result', toolUseId: 'tail-tool', toolName: 'read_file', content: 'Tail command output', isError: false },
+      { role: 'assistant', content: 'Recent answer after tool' },
+      { role: 'user', content: 'Current task stays visible' },
+    )
+
+    await saveSession(cwd, sessionId, messages)
+    const loadedBeforeSnip = await loadSession(cwd, sessionId)
+    assert.ok(loadedBeforeSnip)
+
+    const activeBeforeSnip: ChatMessage[] = [
+      { role: 'system', content: 'System' },
+      ...loadedBeforeSnip!,
+    ]
+    const snipResult = await snipCompactConversation({
+      messages: activeBeforeSnip,
+      contextStats: contextStats(activeBeforeSnip, 20_000),
+      modelContextWindow: 20_000,
+    })
+    assert.equal(snipResult.didSnip, true)
+    assert.equal(snipResult.boundaryMessage?.role, 'snip_boundary')
+    await appendSnipBoundary(
+      cwd,
+      sessionId,
+      snipResult.boundaryMessage as Extract<ChatMessage, { role: 'snip_boundary' }>,
+    )
+    await saveSession(cwd, sessionId, snipResult.messages, 0)
+
+    const loadedAfterSnip = await loadSession(cwd, sessionId)
+    assert.ok(loadedAfterSnip)
+    const loadedAfterSnipIds = new Set(loadedAfterSnip!.map(message => message.id))
+    for (const removedId of snipResult.removedMessageIds) {
+      assert.equal(loadedAfterSnipIds.has(removedId), false)
+    }
+    assert.ok(loadedAfterSnip!.some(message => message.role === 'snip_boundary'))
+    assert.ok(loadedAfterSnip!.some(message => (
+      message.role === 'tool_result' && message.toolUseId === 'tail-tool'
+    )))
+    assertNoToolOrphans(loadedAfterSnip!)
+
+    const adapter: ModelAdapter = {
+      async next(): Promise<AgentStep> {
+        return { type: 'assistant', content: '<summary>Compacted after snip.</summary>' }
+      },
+    }
+    const compactResult = await compactConversation(
+      [{ role: 'system', content: 'System' }, ...loadedAfterSnip!],
+      adapter,
+    )
+    assert.ok(compactResult)
+    await appendCompactBoundary(
+      cwd,
+      sessionId,
+      compactResult.summary.content,
+      'manual',
+      compactResult.tokensBefore,
+      compactResult.tokensAfter,
+      retainedMessagesAfterCompact(compactResult),
+    )
+    await saveSession(cwd, sessionId, compactResult.messages, compactResult.messages.length - 1)
+
+    const loadedAfterCompact = await loadSession(cwd, sessionId)
+    assert.ok(loadedAfterCompact)
+    const loadedAfterCompactIds = new Set(loadedAfterCompact!.map(message => message.id))
+    for (const removedId of snipResult.removedMessageIds) {
+      assert.equal(loadedAfterCompactIds.has(removedId), false)
+    }
+    assert.ok(loadedAfterCompact!.some(message => (
+      'content' in message && message.content === 'Current task stays visible'
+    )))
+    assert.ok(loadedAfterCompact!.some(message => (
+      message.role === 'assistant_tool_call' && message.toolUseId === 'tail-tool'
+    )))
+    assert.ok(loadedAfterCompact!.some(message => (
+      message.role === 'tool_result' && message.toolUseId === 'tail-tool'
+    )))
+    assertNoToolOrphans(loadedAfterCompact!)
   })
 
   it('loadTranscript rebuilds from session envelopes', async () => {

--- a/test/snip-compact.test.ts
+++ b/test/snip-compact.test.ts
@@ -1,0 +1,504 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { AgentStep, ChatMessage, ModelAdapter } from '../src/types.js'
+import type { ContextStats } from '../src/utils/token-estimator.js'
+import { snipCompactConversation } from '../src/compact/snipCompact.js'
+import {
+  SNIP_KEEP_RECENT_MESSAGES,
+  SNIP_MIN_MESSAGES_TO_REMOVE,
+} from '../src/compact/constants.js'
+import {
+  estimateMessagesTokens,
+  tokenCountWithEstimation,
+} from '../src/utils/token-estimator.js'
+import { runAgentTurn } from '../src/agent-loop.js'
+import { ToolRegistry } from '../src/tool.js'
+import { microcompact } from '../src/compact/microcompact.js'
+
+function contextStats(messages: ChatMessage[], effectiveInput = 20_000): ContextStats {
+  const totalTokens = tokenCountWithEstimation(messages).totalTokens
+  const utilization = totalTokens / effectiveInput
+  return {
+    estimatedTokens: estimateMessagesTokens(messages),
+    totalTokens,
+    providerUsageTokens: 0,
+    contextWindow: effectiveInput,
+    effectiveInput,
+    utilization,
+    warningLevel:
+      utilization >= 0.95
+        ? 'blocked'
+        : utilization >= 0.85
+          ? 'critical'
+          : utilization >= 0.50
+            ? 'warning'
+            : 'normal',
+    accounting: tokenCountWithEstimation(messages),
+  }
+}
+
+function withIds(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message, index) => ({
+    ...message,
+    id: `m-${index}`,
+  }) as ChatMessage)
+}
+
+function makeSnippableConversation(options: {
+  oldPairs?: number
+  oldSize?: number
+  recentCount?: number
+} = {}): ChatMessage[] {
+  const oldPairs = options.oldPairs ?? 12
+  const oldSize = options.oldSize ?? 2_000
+  const recentCount = options.recentCount ?? SNIP_KEEP_RECENT_MESSAGES
+  const messages: ChatMessage[] = [
+    { role: 'system', content: 'System prompt' },
+    { role: 'user', content: 'Opening request' },
+  ]
+
+  for (let i = 0; i < oldPairs; i++) {
+    messages.push(
+      { role: 'assistant', content: `Old explanation ${i}: ${'a'.repeat(oldSize)}` },
+      { role: 'user', content: `Old follow-up ${i}: ${'b'.repeat(oldSize)}` },
+    )
+  }
+
+  for (let i = 0; i < recentCount - 1; i++) {
+    messages.push({ role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage)
+  }
+  messages.push({ role: 'user', content: 'Current active task' })
+
+  return withIds(messages)
+}
+
+function assertNoToolOrphans(messages: ChatMessage[]): void {
+  const calls = new Set(
+    messages
+      .filter((message): message is Extract<ChatMessage, { role: 'assistant_tool_call' }> => (
+        message.role === 'assistant_tool_call'
+      ))
+      .map(message => message.toolUseId),
+  )
+  const results = new Set(
+    messages
+      .filter((message): message is Extract<ChatMessage, { role: 'tool_result' }> => (
+        message.role === 'tool_result'
+      ))
+      .map(message => message.toolUseId),
+  )
+
+  for (const id of calls) {
+    assert.ok(results.has(id), `tool call ${id} should keep its result`)
+  }
+  for (const id of results) {
+    assert.ok(calls.has(id), `tool result ${id} should keep its call`)
+  }
+}
+
+describe('snipCompactConversation', () => {
+  it('does not delete system messages', async () => {
+    const messages = makeSnippableConversation()
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.equal(result.messages[0]!.role, 'system')
+    assert.equal(result.messages[0]!.content, 'System prompt')
+  })
+
+  it('does not delete context_summary messages', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'context_summary', content: 'Important summary', compressedCount: 12, timestamp: 1 },
+      ...makeSnippableConversation({ oldPairs: 14 }).slice(1),
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 8_000),
+      modelContextWindow: 8_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => (
+      message.role === 'context_summary' && message.content === 'Important summary'
+    )))
+  })
+
+  it('does not delete the most recent kept messages', async () => {
+    const messages = makeSnippableConversation()
+    const recentIds = messages
+      .slice(-SNIP_KEEP_RECENT_MESSAGES)
+      .map((message, index) => message.id ?? `recent-${index}`)
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    const remainingIds = new Set(result.messages.map(message => message.id))
+    for (const id of recentIds) {
+      assert.ok(remainingIds.has(id), `recent message ${id} should be preserved`)
+    }
+  })
+
+  it('does not delete the latest user message or messages after it', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Opening request' },
+      ...Array.from({ length: 16 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Old ${i}: ${'x'.repeat(2_000)}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Latest active user request' },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES + 3 }, (_, i) => (
+        { role: 'assistant', content: `After latest user ${i}` } as ChatMessage
+      )),
+    ])
+    const protectedIds = messages
+      .slice(messages.findIndex(message => message.content === 'Latest active user request'))
+      .map(message => message.id)
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    const remainingIds = new Set(result.messages.map(message => message.id))
+    for (const id of protectedIds) {
+      assert.ok(remainingIds.has(id), `message after latest user should be preserved: ${id}`)
+    }
+  })
+
+  it('does not split tool_call and tool_result pairs', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      { role: 'assistant', content: 'Old text ' + 'x'.repeat(3_000) },
+      { role: 'assistant_tool_call', toolUseId: 'read-1', toolName: 'read_file', input: { path: 'a.ts' } },
+      { role: 'tool_result', toolUseId: 'read-1', toolName: 'read_file', content: 'file\n'.repeat(2_000), isError: false },
+      { role: 'assistant', content: 'More old text ' + 'y'.repeat(3_000) },
+      { role: 'user', content: 'Another old follow-up ' + 'z'.repeat(3_000) },
+      { role: 'assistant', content: 'Another old answer ' + 'q'.repeat(3_000) },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assertNoToolOrphans(result.messages)
+    const removed = new Set(result.removedMessageIds)
+    assert.equal(removed.has('m-3'), removed.has('m-4'))
+  })
+
+  it('does not delete unclosed tool calls', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      ...Array.from({ length: 10 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Old safe ${i}: ${'x'.repeat(2_000)}` } as ChatMessage
+      )),
+      { role: 'assistant_tool_call', toolUseId: 'open-call', toolName: 'read_file', input: { path: 'unfinished.ts' } },
+      { role: 'assistant', content: 'Important after unclosed call' },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 8_000),
+      modelContextWindow: 8_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => (
+      message.role === 'assistant_tool_call' && message.toolUseId === 'open-call'
+    )))
+  })
+
+  it('protects patch/edit tool groups and their neighboring messages', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      ...Array.from({ length: 12 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Old safe ${i}: ${'x'.repeat(2_000)}` } as ChatMessage
+      )),
+      { role: 'assistant', content: 'Keep before patch' },
+      { role: 'assistant_tool_call', toolUseId: 'patch-1', toolName: 'patch_file', input: { path: 'a.ts' } },
+      { role: 'tool_result', toolUseId: 'patch-1', toolName: 'patch_file', content: 'patched', isError: false },
+      { role: 'assistant', content: 'Keep after patch' },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+    const protectedContents = new Set(['Keep before patch', 'Keep after patch'])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => (
+      message.role === 'assistant_tool_call' && message.toolUseId === 'patch-1'
+    )))
+    assert.ok(result.messages.some(message => (
+      message.role === 'tool_result' && message.toolUseId === 'patch-1'
+    )))
+    for (const content of protectedContents) {
+      assert.ok(result.messages.some(message => (
+        'content' in message && message.content === content
+      )), `${content} should be preserved`)
+    }
+  })
+
+  it('protects important error tool results and their neighboring messages', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      ...Array.from({ length: 12 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Old safe ${i}: ${'x'.repeat(2_000)}` } as ChatMessage
+      )),
+      { role: 'assistant', content: 'Keep before error' },
+      { role: 'assistant_tool_call', toolUseId: 'run-1', toolName: 'run_command', input: { command: 'npm test' } },
+      { role: 'tool_result', toolUseId: 'run-1', toolName: 'run_command', content: 'Traceback: exception failed', isError: false },
+      { role: 'assistant', content: 'Keep after error' },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => (
+      message.role === 'tool_result' && message.toolUseId === 'run-1'
+    )))
+    assert.ok(result.messages.some(message => (
+      'content' in message && message.content === 'Keep before error'
+    )))
+    assert.ok(result.messages.some(message => (
+      'content' in message && message.content === 'Keep after error'
+    )))
+  })
+
+  it('protects ordinary messages with important error markers and their neighbors', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      ...Array.from({ length: 12 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Old safe ${i}: ${'x'.repeat(2_000)}` } as ChatMessage
+      )),
+      { role: 'assistant', content: 'Keep before traceback note' },
+      { role: 'assistant', content: 'Traceback analysis: exception failed in prior command' },
+      { role: 'assistant', content: 'Keep after traceback note' },
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => (
+      'content' in message && message.content === 'Keep before traceback note'
+    )))
+    assert.ok(result.messages.some(message => (
+      'content' in message && message.content === 'Traceback analysis: exception failed in prior command'
+    )))
+    assert.ok(result.messages.some(message => (
+      'content' in message && message.content === 'Keep after traceback note'
+    )))
+  })
+
+  it('deletes an old ordinary contiguous interval and inserts a boundary', async () => {
+    const messages = makeSnippableConversation()
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages),
+      modelContextWindow: 20_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.removedMessageIds.length >= SNIP_MIN_MESSAGES_TO_REMOVE)
+    assert.ok(result.boundaryMessage)
+    assert.equal(result.boundaryMessage!.role, 'snip_boundary')
+    assert.equal(
+      result.messages.filter(message => message.role === 'snip_boundary').length,
+      1,
+    )
+    const removedIndexes = result.removedMessageIds.map(id => Number(id.slice('m-'.length)))
+    for (let i = 1; i < removedIndexes.length; i++) {
+      assert.equal(removedIndexes[i], removedIndexes[i - 1]! + 1)
+    }
+  })
+
+  it('reduces token count after snipping', async () => {
+    const messages = makeSnippableConversation()
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages),
+      modelContextWindow: 20_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.tokensAfter < result.tokensBefore)
+  })
+
+  it('returns didSnip=false when there are too few messages', async () => {
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'x'.repeat(30_000) },
+    ])
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 10_000),
+      modelContextWindow: 10_000,
+    })
+
+    assert.equal(result.didSnip, false)
+  })
+
+  it('returns didSnip=false when there is no safe interval', async () => {
+    const messages: ChatMessage[] = withIds([
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Start' },
+      ...Array.from({ length: 8 }, (_, i) => ([
+        { role: 'assistant_tool_call' as const, toolUseId: `edit-${i}`, toolName: 'edit_file', input: { path: `f${i}.ts` } },
+        { role: 'tool_result' as const, toolUseId: `edit-${i}`, toolName: 'edit_file', content: 'edited\n'.repeat(2_000), isError: false },
+      ])).flat(),
+      ...Array.from({ length: SNIP_KEEP_RECENT_MESSAGES - 1 }, (_, i) => (
+        { role: i % 2 === 0 ? 'assistant' : 'user', content: `Recent ${i}` } as ChatMessage
+      )),
+      { role: 'user', content: 'Current task' },
+    ])
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages, 18_000),
+      modelContextWindow: 18_000,
+    })
+
+    assert.equal(result.didSnip, false)
+  })
+
+  it('does not delete an existing snip_boundary', async () => {
+    const previousBoundary: ChatMessage = {
+      id: 'existing-snip',
+      role: 'snip_boundary',
+      content: '[Snipped earlier conversation segment]',
+      removedMessageIds: ['old-a'],
+      removedCount: 1,
+      tokensFreed: 2_000,
+      timestamp: 1,
+    }
+    const messages = withIds([
+      { role: 'system', content: 'System' },
+      previousBoundary,
+      ...makeSnippableConversation({ oldPairs: 14 }).slice(1),
+    ])
+    messages[1] = previousBoundary
+
+    const result = await snipCompactConversation({
+      messages,
+      contextStats: contextStats(messages),
+      modelContextWindow: 20_000,
+    })
+
+    assert.equal(result.didSnip, true)
+    assert.ok(result.messages.some(message => message.id === 'existing-snip'))
+  })
+
+  it('microcompact does not clear snip_boundary messages', () => {
+    const boundary: ChatMessage = {
+      id: 'snip-boundary',
+      role: 'snip_boundary',
+      content: '[Snipped earlier conversation segment]',
+      removedMessageIds: ['old-1'],
+      removedCount: 1,
+      tokensFreed: 2_000,
+      timestamp: 1,
+    }
+    const bigContent = 'x'.repeat(80_000)
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'System' },
+      boundary,
+      { role: 'assistant_tool_call', toolUseId: 'id-1', toolName: 'read_file', input: {} },
+      { role: 'tool_result', toolUseId: 'id-1', toolName: 'read_file', content: bigContent, isError: false },
+      { role: 'assistant_tool_call', toolUseId: 'id-2', toolName: 'read_file', input: {} },
+      { role: 'tool_result', toolUseId: 'id-2', toolName: 'read_file', content: bigContent, isError: false },
+      { role: 'assistant_tool_call', toolUseId: 'id-3', toolName: 'read_file', input: {} },
+      { role: 'tool_result', toolUseId: 'id-3', toolName: 'read_file', content: bigContent, isError: false },
+      { role: 'assistant_tool_call', toolUseId: 'id-4', toolName: 'read_file', input: {} },
+      { role: 'tool_result', toolUseId: 'id-4', toolName: 'read_file', content: bigContent, isError: false },
+      { role: 'user', content: 'Continue' },
+    ]
+
+    const result = microcompact(messages, 'deepseek-chat')
+
+    assert.ok(result.some(message => (
+      message.role === 'snip_boundary' &&
+      message.content === '[Snipped earlier conversation segment]'
+    )))
+  })
+
+  it('autoCompact uses post-snip stats instead of stale pre-snip usage', async () => {
+    const messages = makeSnippableConversation({
+      oldPairs: 60,
+      oldSize: 5_000,
+      recentCount: SNIP_KEEP_RECENT_MESSAGES,
+    })
+    let modelCalls = 0
+    let didSnip = false
+    const adapter: ModelAdapter = {
+      async next(): Promise<AgentStep> {
+        modelCalls += 1
+        return { type: 'assistant', content: 'Done' }
+      },
+    }
+
+    const result = await runAgentTurn({
+      model: adapter,
+      tools: new ToolRegistry([]),
+      messages,
+      cwd: process.cwd(),
+      modelName: 'deepseek-chat',
+      maxSteps: 1,
+      onSnipCompact() {
+        didSnip = true
+      },
+    })
+
+    assert.equal(didSnip, true)
+    assert.equal(modelCalls, 1, 'autoCompact would have made an extra model call')
+    assert.equal(result.at(-1)?.role, 'assistant')
+  })
+})


### PR DESCRIPTION
## Summary

为 MiniCode 新增 deterministic snip compact。Snip 会在 tool result storage / budget 处理之后、microcompact 之前运行，删除一段安全的旧中间历史区间，并在当前对话中插入 `snip_boundary` 标记。

## Motivation

长会话中会积累较早的中间历史上下文，这些内容会持续占用 token budget，并可能导致系统过早进入 full compact。Snip compact 提供了一个保守的本地上下文清理步骤，可以在不调用模型的情况下缓解 context 压力。

## Implementation

- 新增 deterministic snip heuristic，不调用模型，也不访问网络。
- 将 snip compact 接入到 microcompact 之前，使后续 microcompact 和 auto/full compact 基于更新后的 message list 继续运行。
- 插入 `snip_boundary` metadata，用于记录被移除的 message ids、数量和大致释放的 tokens。
- 更新 session persistence 和 restore 逻辑，通过 `removedMessageIds` 过滤被 snip 的消息，避免 reload 后旧消息重新出现。
- 新增 `/snip` 命令支持。
- 增加 Anthropic message conversion、token estimation 和 compact rendering 对 `snip_boundary` 的兼容。
- 增加 snip 行为和 session restore 兼容性的测试。

## Testing

- `npm run check`
- `npm test`
- `npm run lint --if-present`

## Risks / Notes

- 当前 heuristic 有意保持保守；如果没有安全的连续中间区间可删除，snip 会跳过。
- `snip_boundary` 是内部上下文标记，不代表真实用户请求。
- 如果 snip 无法安全释放足够上下文，系统会继续使用已有的 microcompact 和 auto/full compact 作为 fallback。

part of #1 