### PR TITLE
fix: preserve thinking blocks across tool turns

### DIFF
--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -180,6 +180,7 @@ export async function runAgentTurn(args: {
         })
       ) {
         args.onProgressMessage?.(next.content)
+        appendThinkingBlocks(next.thinkingBlocks)
         messages = [
           ...messages,
           { role: 'assistant_progress', content: next.content },
@@ -244,6 +245,7 @@ export async function runAgentTurn(args: {
             : `模型返回空响应，已停止当前回合。请重试，或要求模型继续。${diagnosticsSuffix}`
 
         args.onAssistantMessage?.(fallbackContent)
+        appendThinkingBlocks(next.thinkingBlocks)
         return [
           ...messages,
           {
@@ -257,6 +259,7 @@ export async function runAgentTurn(args: {
         role: 'assistant',
         content: next.content,
       }
+      appendThinkingBlocks(next.thinkingBlocks)
       const withAssistant: ChatMessage[] = [
         ...messages,
         withProviderUsage(assistantMessage, next.usage),

--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -1,5 +1,11 @@
 import type { ToolRegistry } from './tool.js'
-import type { ChatMessage, CompressionResult, ModelAdapter, ProviderUsage } from './types.js'
+import type {
+  ChatMessage,
+  CompressionResult,
+  ModelAdapter,
+  ProviderThinkingBlock,
+  ProviderUsage,
+} from './types.js'
 import type { PermissionManager } from './permissions.js'
 import { microcompact } from './compact/microcompact.js'
 import { autoCompact } from './compact/auto-compact.js'
@@ -76,6 +82,7 @@ function formatDiagnostics(args: {
 function isRecoverableThinkingStop(args: {
   isEmpty: boolean
   stopReason?: string
+  blockTypes?: string[]
   ignoredBlockTypes?: string[]
 }): boolean {
   if (!args.isEmpty) {
@@ -86,7 +93,10 @@ function isRecoverableThinkingStop(args: {
     return false
   }
 
-  return (args.ignoredBlockTypes ?? []).includes('thinking')
+  return (
+    (args.blockTypes ?? []).includes('thinking') ||
+    (args.ignoredBlockTypes ?? []).includes('thinking')
+  )
 }
 
 export async function runAgentTurn(args: {
@@ -121,6 +131,17 @@ export async function runAgentTurn(args: {
       {
         role: 'user',
         content,
+      },
+    ]
+  }
+
+  const appendThinkingBlocks = (blocks: ProviderThinkingBlock[] | undefined) => {
+    if (!blocks || blocks.length === 0) return
+    messages = [
+      ...messages,
+      {
+        role: 'assistant_thinking',
+        blocks,
       },
     ]
   }
@@ -175,6 +196,7 @@ export async function runAgentTurn(args: {
         isRecoverableThinkingStop({
           isEmpty,
           stopReason: next.diagnostics?.stopReason,
+          blockTypes: next.diagnostics?.blockTypes,
           ignoredBlockTypes: next.diagnostics?.ignoredBlockTypes,
         }) &&
         recoverableThinkingRetryCount < 3
@@ -247,6 +269,8 @@ export async function runAgentTurn(args: {
       return withAssistant
     }
 
+    appendThinkingBlocks(next.thinkingBlocks)
+
     if (next.content) {
       if (next.contentKind === 'progress') {
         args.onProgressMessage?.(next.content)
@@ -315,9 +339,7 @@ export async function runAgentTurn(args: {
       budgetedResults.results.map(result => [result.toolUseId, result]),
     )
 
-    for (let i = 0; i < executedToolResults.length; i++) {
-      const entry = executedToolResults[i]
-      const toolResult = toolResultById.get(entry.call.id) ?? entry.toolResult
+    const toolCallMessages = executedToolResults.map((entry, i) => {
       const toolCallMessage: ChatMessage = {
         role: 'assistant_tool_call',
         toolUseId: entry.call.id,
@@ -325,17 +347,24 @@ export async function runAgentTurn(args: {
         input: entry.call.input,
       }
 
-      messages = [
-        ...messages,
-        withProviderUsage(
-          toolCallMessage,
-          i === executedToolResults.length - 1 ? next.usage : undefined,
-        ),
-        toolResult,
-      ]
+      return withProviderUsage(
+        toolCallMessage,
+        i === executedToolResults.length - 1 ? next.usage : undefined,
+      )
+    })
+    const toolResults = executedToolResults.map(entry =>
+      toolResultById.get(entry.call.id) ?? entry.toolResult,
+    )
 
-      if (entry.result.awaitUser) {
-        const question = entry.result.output.trim()
+    messages = [
+      ...messages,
+      ...toolCallMessages,
+      ...toolResults,
+    ]
+
+    const awaitUserEntry = executedToolResults.find(entry => entry.result.awaitUser)
+    if (awaitUserEntry) {
+      const question = awaitUserEntry.result.output.trim()
         if (question.length > 0) {
           args.onAssistantMessage?.(question)
           messages = [
@@ -347,7 +376,6 @@ export async function runAgentTurn(args: {
           ]
         }
         return messages
-      }
     }
   }
 

--- a/src/anthropic-adapter.ts
+++ b/src/anthropic-adapter.ts
@@ -1,5 +1,12 @@
 import type { ToolRegistry } from './tool.js'
-import type { ChatMessage, ModelAdapter, ProviderUsage, StepDiagnostics, ToolCall } from './types.js'
+import type {
+  ChatMessage,
+  ModelAdapter,
+  ProviderThinkingBlock,
+  ProviderUsage,
+  StepDiagnostics,
+  ToolCall,
+} from './types.js'
 import type { RuntimeConfig } from './config.js'
 import { resolveMaxOutputTokens } from './utils/context.js'
 
@@ -138,6 +145,10 @@ function isToolUseBlock(block: AnthropicContentBlock): block is Extract<Anthropi
   )
 }
 
+function isThinkingBlock(block: AnthropicContentBlock): block is ProviderThinkingBlock {
+  return block.type === 'thinking' || block.type === 'redacted_thinking'
+}
+
 function parseAssistantText(content: string): {
   content: string
   kind?: 'final' | 'progress'
@@ -219,6 +230,58 @@ function pushAnthropicMessage(
   messages.push({ role, content: [block] })
 }
 
+function isAssistantTextMessage(
+  message: ChatMessage,
+): message is Extract<ChatMessage, { role: 'assistant' | 'assistant_progress' }> {
+  return message.role === 'assistant' || message.role === 'assistant_progress'
+}
+
+function normalizeLegacyThinkingToolRounds(messages: ChatMessage[]): ChatMessage[] {
+  const normalized: ChatMessage[] = []
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    if (message.role !== 'assistant_thinking') {
+      normalized.push(message)
+      continue
+    }
+
+    let cursor = i + 1
+    const textMessages: ChatMessage[] = []
+    while (cursor < messages.length && isAssistantTextMessage(messages[cursor])) {
+      textMessages.push(messages[cursor])
+      cursor += 1
+    }
+
+    const toolCalls: ChatMessage[] = []
+    const toolResults: ChatMessage[] = []
+    while (cursor + 1 < messages.length) {
+      const toolCall = messages[cursor]
+      const toolResult = messages[cursor + 1]
+      if (
+        toolCall.role !== 'assistant_tool_call' ||
+        toolResult.role !== 'tool_result' ||
+        toolCall.toolUseId !== toolResult.toolUseId
+      ) {
+        break
+      }
+      toolCalls.push(toolCall)
+      toolResults.push(toolResult)
+      cursor += 2
+    }
+
+    if (toolCalls.length > 1) {
+      normalized.push(message, ...textMessages, ...toolCalls, ...toolResults)
+      i = cursor - 1
+      continue
+    }
+
+    normalized.push(message)
+  }
+
+  return normalized
+}
+
 function toAnthropicMessages(messages: ChatMessage[]): {
   system: string
   messages: AnthropicMessage[]
@@ -229,12 +292,20 @@ function toAnthropicMessages(messages: ChatMessage[]): {
     .join('\n\n')
 
   const converted: AnthropicMessage[] = []
+  const normalizedMessages = normalizeLegacyThinkingToolRounds(messages)
 
-  for (const message of messages) {
+  for (const message of normalizedMessages) {
     if (message.role === 'system') continue
 
     if (message.role === 'user') {
       pushAnthropicMessage(converted, 'user', toTextBlock(message.content))
+      continue
+    }
+
+    if (message.role === 'assistant_thinking') {
+      for (const block of message.blocks) {
+        pushAnthropicMessage(converted, 'assistant', block)
+      }
       continue
     }
 
@@ -348,6 +419,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
 
     const toolCalls: ToolCall[] = []
     const textParts: string[] = []
+    const thinkingBlocks: ProviderThinkingBlock[] = []
     const blockTypes: string[] = []
     const ignoredBlockTypes = new Set<string>()
 
@@ -365,6 +437,11 @@ export class AnthropicModelAdapter implements ModelAdapter {
           toolName: block.name,
           input: block.input,
         })
+        continue
+      }
+
+      if (isThinkingBlock(block)) {
+        thinkingBlocks.push(block)
         continue
       }
 
@@ -388,6 +465,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
           parsedText.kind === 'progress'
             ? ('progress' as const)
             : undefined,
+        thinkingBlocks,
         diagnostics,
         usage,
       }
@@ -397,6 +475,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
       type: 'assistant' as const,
       content: parsedText.content,
       kind: parsedText.kind,
+      thinkingBlocks,
       diagnostics,
       usage,
     }

--- a/src/anthropic-adapter.ts
+++ b/src/anthropic-adapter.ts
@@ -230,58 +230,6 @@ function pushAnthropicMessage(
   messages.push({ role, content: [block] })
 }
 
-function isAssistantTextMessage(
-  message: ChatMessage,
-): message is Extract<ChatMessage, { role: 'assistant' | 'assistant_progress' }> {
-  return message.role === 'assistant' || message.role === 'assistant_progress'
-}
-
-function normalizeLegacyThinkingToolRounds(messages: ChatMessage[]): ChatMessage[] {
-  const normalized: ChatMessage[] = []
-
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i]
-    if (message.role !== 'assistant_thinking') {
-      normalized.push(message)
-      continue
-    }
-
-    let cursor = i + 1
-    const textMessages: ChatMessage[] = []
-    while (cursor < messages.length && isAssistantTextMessage(messages[cursor])) {
-      textMessages.push(messages[cursor])
-      cursor += 1
-    }
-
-    const toolCalls: ChatMessage[] = []
-    const toolResults: ChatMessage[] = []
-    while (cursor + 1 < messages.length) {
-      const toolCall = messages[cursor]
-      const toolResult = messages[cursor + 1]
-      if (
-        toolCall.role !== 'assistant_tool_call' ||
-        toolResult.role !== 'tool_result' ||
-        toolCall.toolUseId !== toolResult.toolUseId
-      ) {
-        break
-      }
-      toolCalls.push(toolCall)
-      toolResults.push(toolResult)
-      cursor += 2
-    }
-
-    if (toolCalls.length > 1) {
-      normalized.push(message, ...textMessages, ...toolCalls, ...toolResults)
-      i = cursor - 1
-      continue
-    }
-
-    normalized.push(message)
-  }
-
-  return normalized
-}
-
 function toAnthropicMessages(messages: ChatMessage[]): {
   system: string
   messages: AnthropicMessage[]
@@ -292,9 +240,8 @@ function toAnthropicMessages(messages: ChatMessage[]): {
     .join('\n\n')
 
   const converted: AnthropicMessage[] = []
-  const normalizedMessages = normalizeLegacyThinkingToolRounds(messages)
 
-  for (const message of normalizedMessages) {
+  for (const message of messages) {
     if (message.role === 'system') continue
 
     if (message.role === 'user') {

--- a/src/compact/compact.ts
+++ b/src/compact/compact.ts
@@ -10,43 +10,49 @@ import { buildCompactSummaryPrompt, parseSummaryFromResponse } from './prompt.js
 
 function groupMessagesByApiRound(messages: ChatMessage[]): ChatMessage[][] {
   const groups: ChatMessage[][] = []
-  let currentGroup: ChatMessage[] = []
 
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i]
+  for (let i = 0; i < messages.length;) {
+    const group: ChatMessage[] = []
+    let cursor = i
 
-    if (msg.role === 'assistant_tool_call') {
-      currentGroup.push(msg)
-      if (i + 1 < messages.length && messages[i + 1].role === 'tool_result') {
-        currentGroup.push(messages[i + 1])
-        i++
-      }
-      groups.push(currentGroup)
-      currentGroup = []
+    if (messages[cursor]?.role === 'assistant_thinking') {
+      group.push(messages[cursor])
+      cursor += 1
+    }
+
+    while (messages[cursor]?.role === 'assistant_tool_call') {
+      group.push(messages[cursor])
+      cursor += 1
+    }
+
+    while (messages[cursor]?.role === 'tool_result') {
+      group.push(messages[cursor])
+      cursor += 1
+    }
+
+    if (group.some(msg => msg.role === 'assistant_tool_call' || msg.role === 'tool_result')) {
+      groups.push(group)
+      i = cursor
       continue
     }
 
-    if (msg.role === 'tool_result') {
-      currentGroup.push(msg)
-      if (i + 1 < messages.length && messages[i + 1].role !== 'tool_result') {
-        groups.push(currentGroup)
-        currentGroup = []
-      }
-      continue
-    }
-
-    if (currentGroup.length > 0) {
-      groups.push(currentGroup)
-      currentGroup = []
-    }
-    groups.push([msg])
-  }
-
-  if (currentGroup.length > 0) {
-    groups.push(currentGroup)
+    groups.push([messages[i]])
+    i += 1
   }
 
   return groups
+}
+
+function alignBoundaryToApiRound(messages: ChatMessage[], boundary: number): number {
+  let start = 0
+  for (const group of groupMessagesByApiRound(messages)) {
+    const end = start + group.length
+    if (boundary > start && boundary < end) {
+      return start
+    }
+    start = end
+  }
+  return boundary
 }
 
 function findRetentionBoundary(messages: ChatMessage[]): number {
@@ -76,23 +82,7 @@ function findRetentionBoundary(messages: ChatMessage[]): number {
     boundary = Math.max(1, messages.length - RETENTION.MIN_KEEP_MESSAGES)
   }
 
-  // Ensure we don't split tool_use/tool_result pairs.
-  // If boundary lands on a tool_result, scan backward to find its matching tool_use.
-  if (boundary < messages.length) {
-    const msg = messages[boundary]
-    if (msg.role === 'tool_result') {
-      const toolUseId = msg.toolUseId
-      for (let i = boundary - 1; i >= 1; i--) {
-        const prev = messages[i]
-        if (prev.role === 'assistant_tool_call' && prev.toolUseId === toolUseId) {
-          boundary = i
-          break
-        }
-      }
-    }
-  }
-
-  return boundary
+  return alignBoundaryToApiRound(messages, boundary)
 }
 
 function messagesToText(messages: ChatMessage[]): string {
@@ -105,6 +95,9 @@ function messagesToText(messages: ChatMessage[]): string {
       case 'assistant':
       case 'assistant_progress':
         parts.push(`[Assistant]: ${msg.content}`)
+        break
+      case 'assistant_thinking':
+        parts.push('[Assistant Thinking]: preserved provider reasoning block')
         break
       case 'assistant_tool_call':
         parts.push(`[Tool Call: ${msg.toolName}]: ${JSON.stringify(msg.input)}`)

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import type { ChatMessage } from './types.js'
 
 const MAX_TITLE_LENGTH = 60
 
-type EventType = 'system' | 'user' | 'assistant' | 'progress' | 'tool_call' | 'tool_result' | 'summary' | 'compact_boundary' | 'rename'
+type EventType = 'system' | 'user' | 'assistant' | 'thinking' | 'progress' | 'tool_call' | 'tool_result' | 'summary' | 'compact_boundary' | 'rename'
 
 type SessionEvent = {
   type: EventType
@@ -47,6 +47,7 @@ function roleToType(role: string): EventType {
     case 'system': return 'system'
     case 'user': return 'user'
     case 'assistant': return 'assistant'
+    case 'assistant_thinking': return 'thinking'
     case 'assistant_progress': return 'progress'
     case 'assistant_tool_call': return 'tool_call'
     case 'tool_result': return 'tool_result'

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,15 @@ export type ProviderUsageMetadata = {
   usageStaleReason?: string
 }
 
+export type ProviderThinkingBlock = {
+  type: 'thinking' | 'redacted_thinking'
+  [key: string]: unknown
+}
+
 export type ChatMessage =
   | { role: 'system'; content: string }
   | { role: 'user'; content: string }
+  | { role: 'assistant_thinking'; blocks: ProviderThinkingBlock[] }
   | ({ role: 'assistant'; content: string } & ProviderUsageMetadata)
   | ({ role: 'assistant_progress'; content: string } & ProviderUsageMetadata)
   | ({
@@ -53,6 +59,7 @@ export type AgentStep =
       type: 'assistant'
       content: string
       kind?: 'final' | 'progress'
+      thinkingBlocks?: ProviderThinkingBlock[]
       diagnostics?: StepDiagnostics
       usage?: ProviderUsage
     }
@@ -61,6 +68,7 @@ export type AgentStep =
       calls: ToolCall[]
       content?: string
       contentKind?: 'progress'
+      thinkingBlocks?: ProviderThinkingBlock[]
       diagnostics?: StepDiagnostics
       usage?: ProviderUsage
     }

--- a/src/utils/token-estimator.ts
+++ b/src/utils/token-estimator.ts
@@ -34,6 +34,7 @@ export type ContextStats = {
 const CHARS_PER_TOKEN: Record<string, number> = {
   system: 3.5,
   user: 3.0,
+  assistant_thinking: 3.0,
   assistant: 3.5,
   assistant_progress: 3.5,
   assistant_tool_call: 2.5,
@@ -50,6 +51,12 @@ function messageContentLength(message: ChatMessage): number {
     case 'assistant':
     case 'assistant_progress':
       return message.content.length
+    case 'assistant_thinking':
+      try {
+        return JSON.stringify(message.blocks).length
+      } catch {
+        return 0
+      }
     case 'assistant_tool_call':
       try {
         return JSON.stringify(message.input).length

--- a/test/anthropic-thinking-roundtrip.test.ts
+++ b/test/anthropic-thinking-roundtrip.test.ts
@@ -173,52 +173,6 @@ describe('Anthropic thinking block round trip', () => {
     )
   })
 
-  it('normalizes legacy interleaved tool history before sending it to the provider', async () => {
-    const requests: unknown[] = []
-
-    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-      requests.push(JSON.parse(String(init?.body ?? '{}')))
-      return new Response(JSON.stringify({
-        stop_reason: 'end_turn',
-        content: [{ type: 'text', text: '<final>done' }],
-      }), { status: 200 })
-    }) as typeof fetch
-
-    const tools = createEchoTools()
-    const adapter = new AnthropicModelAdapter(tools, async () => createRuntime())
-    const messages: ChatMessage[] = [
-      { role: 'system', content: 'System' },
-      { role: 'user', content: 'Use two tools' },
-      {
-        role: 'assistant_thinking',
-        blocks: [{ type: 'thinking', thinking: 'I need two facts.', signature: 'legacy-signature' }],
-      },
-      { role: 'assistant_tool_call', toolUseId: 'toolu_1', toolName: 'echo_tool', input: { value: 'one' } },
-      { role: 'tool_result', toolUseId: 'toolu_1', toolName: 'echo_tool', content: 'one', isError: false },
-      { role: 'assistant_tool_call', toolUseId: 'toolu_2', toolName: 'echo_tool', input: { value: 'two' } },
-      { role: 'tool_result', toolUseId: 'toolu_2', toolName: 'echo_tool', content: 'two', isError: false },
-    ]
-
-    await adapter.next(messages)
-
-    const request = requests[0] as {
-      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>
-    }
-    const assistantMessages = request.messages.filter(message => message.role === 'assistant')
-    const toolResultMessages = request.messages.filter(message => message.role === 'user' &&
-      message.content.some(block => block.type === 'tool_result'))
-
-    assert.equal(assistantMessages.length, 1)
-    assert.deepEqual(
-      assistantMessages[0]!.content.map(block => block.type),
-      ['thinking', 'tool_use', 'tool_use'],
-    )
-    assert.deepEqual(
-      toolResultMessages[0]!.content.map(block => block.tool_use_id),
-      ['toolu_1', 'toolu_2'],
-    )
-  })
-
   it('preserves final assistant thinking blocks for the next user prompt', async () => {
     const requests: unknown[] = []
     let callCount = 0

--- a/test/anthropic-thinking-roundtrip.test.ts
+++ b/test/anthropic-thinking-roundtrip.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { AnthropicModelAdapter } from '../src/anthropic-adapter.js'
+import { runAgentTurn } from '../src/agent-loop.js'
+import { ToolRegistry } from '../src/tool.js'
+import type { RuntimeConfig } from '../src/config.js'
+import type { ChatMessage } from '../src/types.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+describe('Anthropic thinking block round trip', () => {
+  it('preserves thinking blocks when continuing after tool results', async () => {
+    const requests: unknown[] = []
+    let callCount = 0
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body ?? '{}')))
+      callCount += 1
+
+      if (callCount === 1) {
+        return new Response(JSON.stringify({
+          stop_reason: 'tool_use',
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'I should inspect the workspace before answering.',
+              signature: 'opaque-signature',
+            },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'echo_tool',
+              input: { value: 'ok' },
+            },
+          ],
+        }), { status: 200 })
+      }
+
+      return new Response(JSON.stringify({
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: '<final>done' }],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    const tools = new ToolRegistry([
+      {
+        name: 'echo_tool',
+        description: 'Echoes a test value.',
+        inputSchema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          required: ['value'],
+        },
+        schema: z.object({ value: z.string() }),
+        async run(input) {
+          return { ok: true, output: input.value }
+        },
+      },
+    ])
+    const runtime: RuntimeConfig = {
+      model: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com/anthropic',
+      authToken: 'test-token',
+      mcpServers: {},
+      sourceSummary: 'test',
+    }
+    const adapter = new AnthropicModelAdapter(tools, async () => runtime)
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Summarize this project' },
+    ]
+
+    await runAgentTurn({
+      model: adapter,
+      tools,
+      messages,
+      cwd: process.cwd(),
+    })
+
+    assert.equal(requests.length, 2)
+    const secondRequest = requests[1] as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>
+    }
+    const assistantWithToolUse = secondRequest.messages.find(message =>
+      message.role === 'assistant' &&
+      message.content.some(block => block.type === 'tool_use')
+    )
+
+    assert.ok(assistantWithToolUse)
+    assert.deepEqual(
+      assistantWithToolUse.content.map(block => block.type),
+      ['thinking', 'tool_use'],
+    )
+    assert.deepEqual(assistantWithToolUse.content[0], {
+      type: 'thinking',
+      thinking: 'I should inspect the workspace before answering.',
+      signature: 'opaque-signature',
+    })
+  })
+
+  it('keeps parallel tool uses in the same assistant message with their thinking block', async () => {
+    const requests: unknown[] = []
+    let callCount = 0
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body ?? '{}')))
+      callCount += 1
+
+      if (callCount === 1) {
+        return new Response(JSON.stringify({
+          stop_reason: 'tool_use',
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'I need two independent facts.',
+              signature: 'parallel-signature',
+            },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'echo_tool',
+              input: { value: 'one' },
+            },
+            {
+              type: 'tool_use',
+              id: 'toolu_2',
+              name: 'echo_tool',
+              input: { value: 'two' },
+            },
+          ],
+        }), { status: 200 })
+      }
+
+      return new Response(JSON.stringify({
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: '<final>done' }],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    const tools = createEchoTools()
+    const adapter = new AnthropicModelAdapter(tools, async () => createRuntime())
+
+    await runAgentTurn({
+      model: adapter,
+      tools,
+      messages: [
+        { role: 'system', content: 'System' },
+        { role: 'user', content: 'Use two tools' },
+      ],
+      cwd: process.cwd(),
+    })
+
+    const secondRequest = requests[1] as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>
+    }
+    const assistantMessages = secondRequest.messages.filter(message => message.role === 'assistant')
+    const toolResultMessages = secondRequest.messages.filter(message => message.role === 'user' &&
+      message.content.some(block => block.type === 'tool_result'))
+
+    assert.equal(assistantMessages.length, 1)
+    assert.deepEqual(
+      assistantMessages[0]!.content.map(block => block.type),
+      ['thinking', 'tool_use', 'tool_use'],
+    )
+    assert.deepEqual(
+      toolResultMessages[0]!.content.map(block => block.tool_use_id),
+      ['toolu_1', 'toolu_2'],
+    )
+  })
+
+  it('normalizes legacy interleaved tool history before sending it to the provider', async () => {
+    const requests: unknown[] = []
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body ?? '{}')))
+      return new Response(JSON.stringify({
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: '<final>done' }],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    const tools = createEchoTools()
+    const adapter = new AnthropicModelAdapter(tools, async () => createRuntime())
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'System' },
+      { role: 'user', content: 'Use two tools' },
+      {
+        role: 'assistant_thinking',
+        blocks: [{ type: 'thinking', thinking: 'I need two facts.', signature: 'legacy-signature' }],
+      },
+      { role: 'assistant_tool_call', toolUseId: 'toolu_1', toolName: 'echo_tool', input: { value: 'one' } },
+      { role: 'tool_result', toolUseId: 'toolu_1', toolName: 'echo_tool', content: 'one', isError: false },
+      { role: 'assistant_tool_call', toolUseId: 'toolu_2', toolName: 'echo_tool', input: { value: 'two' } },
+      { role: 'tool_result', toolUseId: 'toolu_2', toolName: 'echo_tool', content: 'two', isError: false },
+    ]
+
+    await adapter.next(messages)
+
+    const request = requests[0] as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>
+    }
+    const assistantMessages = request.messages.filter(message => message.role === 'assistant')
+    const toolResultMessages = request.messages.filter(message => message.role === 'user' &&
+      message.content.some(block => block.type === 'tool_result'))
+
+    assert.equal(assistantMessages.length, 1)
+    assert.deepEqual(
+      assistantMessages[0]!.content.map(block => block.type),
+      ['thinking', 'tool_use', 'tool_use'],
+    )
+    assert.deepEqual(
+      toolResultMessages[0]!.content.map(block => block.tool_use_id),
+      ['toolu_1', 'toolu_2'],
+    )
+  })
+})
+
+function createRuntime(): RuntimeConfig {
+  return {
+    model: 'deepseek-v4-flash',
+    baseUrl: 'https://api.deepseek.com/anthropic',
+    authToken: 'test-token',
+    mcpServers: {},
+    sourceSummary: 'test',
+  }
+}
+
+function createEchoTools(): ToolRegistry {
+  return new ToolRegistry([
+    {
+      name: 'echo_tool',
+      description: 'Echoes a test value.',
+      inputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+      },
+      schema: z.object({ value: z.string() }),
+      async run(input) {
+        return { ok: true, output: input.value }
+      },
+    },
+  ])
+}

--- a/test/anthropic-thinking-roundtrip.test.ts
+++ b/test/anthropic-thinking-roundtrip.test.ts
@@ -218,6 +218,90 @@ describe('Anthropic thinking block round trip', () => {
       ['toolu_1', 'toolu_2'],
     )
   })
+
+  it('preserves final assistant thinking blocks for the next user prompt', async () => {
+    const requests: unknown[] = []
+    let callCount = 0
+
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body ?? '{}')))
+      callCount += 1
+
+      if (callCount === 1) {
+        return new Response(JSON.stringify({
+          stop_reason: 'tool_use',
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'I need to inspect a fact first.',
+              signature: 'tool-thinking-signature',
+            },
+            {
+              type: 'tool_use',
+              id: 'toolu_1',
+              name: 'echo_tool',
+              input: { value: 'one' },
+            },
+          ],
+        }), { status: 200 })
+      }
+
+      if (callCount === 2) {
+        return new Response(JSON.stringify({
+          stop_reason: 'end_turn',
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'I have the tool result and can answer.',
+              signature: 'final-thinking-signature',
+            },
+            { type: 'text', text: '<final>done' },
+          ],
+        }), { status: 200 })
+      }
+
+      return new Response(JSON.stringify({
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: '<final>continued' }],
+      }), { status: 200 })
+    }) as typeof fetch
+
+    const tools = createEchoTools()
+    const adapter = new AnthropicModelAdapter(tools, async () => createRuntime())
+    const firstTurn = await runAgentTurn({
+      model: adapter,
+      tools,
+      messages: [
+        { role: 'system', content: 'System' },
+        { role: 'user', content: 'Use a tool then answer' },
+      ],
+      cwd: process.cwd(),
+    })
+
+    await adapter.next([
+      ...firstTurn,
+      { role: 'user', content: 'Continue from the answer' },
+    ])
+
+    const thirdRequest = requests[2] as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>
+    }
+    const finalAssistant = thirdRequest.messages.find(message =>
+      message.role === 'assistant' &&
+      message.content.some(block => block.type === 'text' && block.text === 'done')
+    )
+
+    assert.ok(finalAssistant)
+    assert.deepEqual(
+      finalAssistant.content.map(block => block.type),
+      ['thinking', 'text'],
+    )
+    assert.deepEqual(finalAssistant.content[0], {
+      type: 'thinking',
+      thinking: 'I have the tool result and can answer.',
+      signature: 'final-thinking-signature',
+    })
+  })
 })
 
 function createRuntime(): RuntimeConfig {

--- a/test/compact.test.ts
+++ b/test/compact.test.ts
@@ -180,6 +180,30 @@ describe('groupMessagesByApiRound', () => {
     assert.ok(toolGroup)
     assert.ok(toolGroup!.some(m => m.role === 'tool_result'), 'tool_result should be in same group as tool_use')
   })
+
+  it('groups thinking with parallel tool uses and their results', () => {
+    const messages: ChatMessage[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant_thinking', blocks: [{ type: 'thinking', thinking: 'plan', signature: 'sig' }] },
+      { role: 'assistant_tool_call', toolUseId: '1', toolName: 'read_file', input: { path: 'a.ts' } },
+      { role: 'assistant_tool_call', toolUseId: '2', toolName: 'read_file', input: { path: 'b.ts' } },
+      { role: 'tool_result', toolUseId: '1', toolName: 'read_file', content: 'a', isError: false },
+      { role: 'tool_result', toolUseId: '2', toolName: 'read_file', content: 'b', isError: false },
+      { role: 'assistant', content: 'Done' },
+    ]
+
+    const groups = groupMessagesByApiRound(messages)
+    const toolGroup = groups.find(g => g.some(m => m.role === 'assistant_thinking'))
+
+    assert.ok(toolGroup)
+    assert.deepEqual(toolGroup!.map(m => m.role), [
+      'assistant_thinking',
+      'assistant_tool_call',
+      'assistant_tool_call',
+      'tool_result',
+      'tool_result',
+    ])
+  })
 })
 
 describe('findRetentionBoundary', () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -96,6 +96,7 @@ describe('session persistence', () => {
       { role: 'system', content: 'sys' },
       { role: 'user', content: 'hello' },
       { role: 'assistant', content: 'hi' },
+      { role: 'assistant_thinking', blocks: [{ type: 'thinking', thinking: 'hidden reasoning', signature: 'sig' }] },
       { role: 'assistant_tool_call', toolUseId: 'c1', toolName: 'read_file', input: { path: '/a.ts' } },
       { role: 'tool_result', toolUseId: 'c1', toolName: 'read_file', content: 'file contents', isError: false },
       { role: 'context_summary', content: 'summary text', compressedCount: 5, timestamp: 12345 },
@@ -104,12 +105,13 @@ describe('session persistence', () => {
     await saveSession(cwd, 'types001', messages)
     const loaded = await loadSession(cwd, 'types001')
 
-    assert.equal(loaded!.length, 5)
+    assert.equal(loaded!.length, 6)
     assert.equal(loaded![0].role, 'user')
     assert.equal(loaded![1].role, 'assistant')
-    assert.equal(loaded![2].role, 'assistant_tool_call')
-    assert.equal(loaded![3].role, 'tool_result')
-    assert.equal(loaded![4].role, 'context_summary')
+    assert.equal(loaded![2].role, 'assistant_thinking')
+    assert.equal(loaded![3].role, 'assistant_tool_call')
+    assert.equal(loaded![4].role, 'tool_result')
+    assert.equal(loaded![5].role, 'context_summary')
   })
 
   it('stores events in envelope jsonl format', async () => {


### PR DESCRIPTION
## Summary

Fixes Anthropic-compatible thinking mode failures when tool calls and final assistant responses are replayed in later requests.

The runtime now preserves provider `thinking` / `redacted_thinking` blocks across tool calls, parallel tool calls, and final assistant responses so new conversation history is replayed in the shape required by Anthropic-compatible providers such as DeepSeek V4.

## Changes

- Add an internal `assistant_thinking` message type for provider thinking blocks.
- Preserve and replay `thinking` / `redacted_thinking` blocks from Anthropic-compatible responses.
- Store all tool calls from one model response before appending their tool results.
- Keep `thinking + N tool_use + N tool_result` groups together during compaction boundary selection.
- Preserve thinking blocks from final assistant responses for the next user prompt.
- Add regression tests for:
  - single tool call thinking replay
  - parallel tool call thinking replay
  - final assistant thinking replay across user prompts
  - compaction grouping for thinking/tool/result rounds

## Verification

- `node --import tsx --test test/anthropic-thinking-roundtrip.test.ts`
- `npm.cmd run check`
- `npm.cmd run test`