### PR TITLE
chore: add MiniCode4j external implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/MiniCode-Python"]
 	path = external/MiniCode-Python
 	url = https://github.com/QUSETIONS/MiniCode-Python.git
+[submodule "external/MiniCode4j"]
+	path = external/MiniCode4j
+	url = https://github.com/hobbescalvin414-tech/minicode4j.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "external/MiniCode4j"]
 	path = external/MiniCode4j
 	url = https://github.com/hobbescalvin414-tech/minicode4j.git
+	branch = feat/default-ts-ui


### PR DESCRIPTION
## Summary

This PR adds MiniCode4j as an external Java implementation under `external/MiniCode4j`.

MiniCode4j keeps Java as the core agent runtime and uses a TypeScript terminal UI frontend. The submodule points to the latest `feat/default-ts-ui` version of the MiniCode4j repository.

Repository:
https://github.com/hobbescalvin414-tech/minicode4j

## Included

- Adds/updates `external/MiniCode4j` as a Git submodule.
- Points the submodule to MiniCode4j commit `4ee1c62` on `feat/default-ts-ui`.
- Records `branch = feat/default-ts-ui` in `.gitmodules`.

## Notes

MiniCode4j remains an external implementation. The TypeScript frontend only handles terminal UI and does not access provider, tool, session, storage, prompt, or schema internals directly.