### PR TITLE
Add external MiniCode-go submodule and README links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = external/MiniCode4j
 	url = https://github.com/hobbescalvin414-tech/minicode4j.git
 	branch = feat/default-ts-ui
+[submodule "external/MiniCode-go"]
+	path = external/MiniCode-go
+	url = https://github.com/ssbsunshengbo/MiniCode.git

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Summaries are based on the main repository and multi-language branch commit hist
 - TypeScript (this repo): [MiniCode](https://github.com/LiuMengxuan04/MiniCode)
 - Rust version: [MiniCode-rs](https://github.com/harkerhand/MiniCode-rs/tree/master)
 - Python version: [MiniCode-Python](https://github.com/QUSETIONS/MiniCode-Python)
+- Go version: [MiniCode-go](https://github.com/ssbsunshengbo/MiniCode)
 - Java version: [MiniCode4j](https://github.com/hobbescalvin414-tech/minicode4j/tree/feat/default-ts-ui)
 
 ## Product Showcase Page

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,6 +103,7 @@ MiniCode 围绕一个 terminal-first agent loop 构建：
 - TypeScript（本仓库）：[MiniCode](https://github.com/LiuMengxuan04/MiniCode)
 - Rust 版本：[MiniCode-rs](https://github.com/harkerhand/MiniCode-rs/tree/master)
 - Python 版本：[MiniCode-Python](https://github.com/QUSETIONS/MiniCode-Python)
+- Go 版本：[MiniCode-go](https://github.com/ssbsunshengbo/MiniCode)
 - Java 版本：[MiniCode4j](https://github.com/hobbescalvin414-tech/minicode4j/tree/feat/default-ts-ui)
 
 ## 产品展示页


### PR DESCRIPTION
## Summary

This PR adds the Go implementation of MiniCode to the main repository in two ways:

- adds `MiniCode-go` to the multi-language version links in README
- adds `external/MiniCode-go` as a Git submodule

## Why

The Go version has grown beyond a simple port and now includes a fuller runtime architecture, session persistence, OpenAI-compatible provider support, MCP integration, permission controls, and a native TUI implementation.

Adding it to the main repository makes the multi-language ecosystem easier to discover and keeps the TypeScript main repo as the central index.

## Notes

- the Go implementation continues to live and evolve in its own repository
- the submodule keeps language implementations decoupled while giving the main repo a unified entry point