### PR TITLE
Add MiniCode-go external module and showcase links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -655,12 +655,15 @@
         <a class="btn btn-secondary" href="https://github.com/QUSETIONS/MiniCode-Python" target="_blank" data-i18n="btn_python">
           Python Version
         </a>
+        <a class="btn btn-secondary" href="https://github.com/ssbsunshengbo/MiniCode-go" target="_blank" data-i18n="btn_go">
+          Go Version
+        </a>
         <a class="btn btn-secondary" href="https://github.com/hobbescalvin414-tech/minicode4j/tree/feat/default-ts-ui" target="_blank" data-i18n="btn_java">
           Java Version
         </a>
       </div>
       <p class="fade-up delay-300" data-i18n="multi_lang_note" style="margin-top: 16px; font-size: 0.95rem; color: var(--text-tertiary);">
-        Multi-language roadmap: Rust, Python, and Java versions are now available.
+        Multi-language roadmap: Rust, Python, Go, and Java versions are now available.
       </p>
     </header>
 
@@ -974,8 +977,9 @@
         btn_readme: "Read Documentation",
         btn_rust: "Rust Version",
         btn_python: "Python Version",
+        btn_go: "Go Version",
         btn_java: "Java Version",
-        multi_lang_note: "Multi-language roadmap: Rust, Python, and Java versions are now available.",
+        multi_lang_note: "Multi-language roadmap: Rust, Python, Go, and Java versions are now available.",
         t_header_desc: "Terminal coding assistant with a card-style session layout.",
         t_events: "6 events",
         t_feed: "session feed",
@@ -1069,8 +1073,9 @@
         btn_readme: "阅读中文文档",
         btn_rust: "Rust 版本",
         btn_python: "Python 版本",
+        btn_go: "Go 版本",
         btn_java: "Java 版本",
-        multi_lang_note: "多语言路线：Rust、Python 与 Java 版本均已上线。",
+        multi_lang_note: "多语言路线：Rust、Python、Go 与 Java 版本均已上线。",
         t_header_desc: "采用卡片式会话布局的终端编码助手。",
         t_events: "6 条事件",
         t_feed: "会话内容",


### PR DESCRIPTION
## Summary

This PR adds the Go implementation of MiniCode to the main repository in three places:

- adds `MiniCode-go` to the multi-language links in `README.md`
- adds `MiniCode-go` to the multi-language links in `README.zh-CN.md`
- adds `external/MiniCode-go` as a Git submodule
- updates `docs/index.html` so the showcase page includes a Go version button and updated multi-language copy

## Why

The Go version has grown beyond a simple port and now includes a fuller runtime architecture, session persistence, OpenAI-compatible provider support, MCP integration, permission controls, and a native TUI implementation.

Adding it to the main repository makes the multi-language ecosystem easier to discover and keeps the TypeScript main repo as the central index.

## Notes

- the Go implementation continues to live and evolve in its own repository
- the submodule keeps language implementations decoupled while giving the main repo a unified entry point