### PR TITLE
feat: show remaining context headroom in TUI badge

### DIFF
--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -114,6 +114,16 @@ function colorBadge(
   return `${color}[${label}]${RESET} ${BOLD}${value}${RESET}`
 }
 
+function formatCompactTokenCount(tokens: number): string {
+  const value = Math.max(0, Math.floor(tokens))
+  if (value < 1_000) return String(value)
+  if (value < 1_000_000) return `${Math.round(value / 1_000)}K`
+
+  const millions = value / 1_000_000
+  const formatted = millions.toFixed(1).replace(/\.0$/, '')
+  return `${formatted}M`
+}
+
 function joinSegmentsWithinWidth(
   segments: string[],
   separator: string,
@@ -232,6 +242,7 @@ export function renderPanel(
 export function renderContextBadge(stats: {
   utilization: number
   warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
+  remainingTokens?: number
   accounting?: {
     providerUsageTokens: number
     estimatedTokens: number
@@ -251,6 +262,10 @@ export function renderContextBadge(stats: {
 
   const filled = Math.round(utilization * 10)
   const bar = '\u2593'.repeat(filled) + '\u2591'.repeat(10 - filled)
+  const headroom =
+    stats.remainingTokens !== undefined
+      ? ` ${formatCompactTokenCount(stats.remainingTokens)} left`
+      : ''
   const sourceLabel =
     accounting?.source === 'provider_usage'
       ? 'usage'
@@ -261,7 +276,7 @@ export function renderContextBadge(stats: {
           : ''
   const suffix = sourceLabel ? ` ${sourceLabel}` : ''
 
-  return colorBadge('ctx', `${percent}% ${bar}${suffix}`, color)
+  return colorBadge('ctx', `${percent}% ${bar}${headroom}${suffix}`, color)
 }
 
 export function renderBanner(
@@ -279,6 +294,7 @@ export function renderBanner(
     contextStats?: {
       utilization: number
       warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
+      remainingTokens?: number
       accounting?: {
         providerUsageTokens: number
         estimatedTokens: number

--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -4,6 +4,7 @@ import process from 'node:process'
 import type { RuntimeConfig } from '../config.js'
 import type { SlashCommand } from '../cli-commands.js'
 import type { PermissionRequest } from '../permissions.js'
+import type { ContextStats } from '../utils/token-estimator.js'
 
 const RESET = '\u001b[0m'
 const DIM = '\u001b[2m'
@@ -117,8 +118,15 @@ function colorBadge(
 function formatCompactTokenCount(tokens: number): string {
   const value = Math.max(0, Math.floor(tokens))
   if (value < 1_000) return String(value)
-  if (value < 1_000_000) return `${Math.round(value / 1_000)}K`
+  if (value < 1_000_000) {
+    const thousands = Math.round(value / 1_000)
+    return thousands >= 1_000 ? formatCompactMillionTokenCount(value) : `${thousands}K`
+  }
 
+  return formatCompactMillionTokenCount(value)
+}
+
+function formatCompactMillionTokenCount(value: number): string {
   const millions = value / 1_000_000
   const formatted = millions.toFixed(1).replace(/\.0$/, '')
   return `${formatted}M`
@@ -242,7 +250,7 @@ export function renderPanel(
 export function renderContextBadge(stats: {
   utilization: number
   warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
-  remainingTokens?: number
+  remainingTokens: number
   accounting?: {
     providerUsageTokens: number
     estimatedTokens: number
@@ -262,10 +270,7 @@ export function renderContextBadge(stats: {
 
   const filled = Math.round(utilization * 10)
   const bar = '\u2593'.repeat(filled) + '\u2591'.repeat(10 - filled)
-  const headroom =
-    stats.remainingTokens !== undefined
-      ? ` ${formatCompactTokenCount(stats.remainingTokens)} left`
-      : ''
+  const headroom = ` ${formatCompactTokenCount(stats.remainingTokens)} left`
   const sourceLabel =
     accounting?.source === 'provider_usage'
       ? 'usage'
@@ -291,16 +296,7 @@ export function renderBanner(
     mcpConnectedCount: number
     mcpConnectingCount: number
     mcpErrorCount: number
-    contextStats?: {
-      utilization: number
-      warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
-      remainingTokens?: number
-      accounting?: {
-        providerUsageTokens: number
-        estimatedTokens: number
-        source: 'provider_usage' | 'provider_usage_plus_estimate' | 'estimate_only'
-      }
-    } | null
+    contextStats?: ContextStats | null
   },
 ): string {
   const panelWidth = Math.max(60, process.stdout.columns ?? 100)

--- a/src/utils/token-estimator.ts
+++ b/src/utils/token-estimator.ts
@@ -26,6 +26,7 @@ export type ContextStats = {
   providerUsageTokens: number
   contextWindow: number
   effectiveInput: number
+  remainingTokens: number
   utilization: number
   warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
   accounting: TokenAccountingResult
@@ -181,6 +182,7 @@ export function computeContextStats(
   const window = getModelContextWindow(model)
   const accounting = tokenCountWithEstimation(messages)
   const utilization = Math.min(1, accounting.totalTokens / window.effectiveInput)
+  const remainingTokens = Math.max(0, window.effectiveInput - accounting.totalTokens)
 
   let warningLevel: ContextStats['warningLevel']
   if (utilization >= 0.95) {
@@ -199,6 +201,7 @@ export function computeContextStats(
     providerUsageTokens: accounting.providerUsageTokens,
     contextWindow: window.contextWindow,
     effectiveInput: window.effectiveInput,
+    remainingTokens,
     utilization,
     warningLevel,
     accounting,

--- a/test/context-badge.test.ts
+++ b/test/context-badge.test.ts
@@ -8,7 +8,11 @@ function stripAnsi(input: string): string {
 
 describe('renderContextBadge', () => {
   it('renders normal level badge', () => {
-    const result = renderContextBadge({ utilization: 0.23, warningLevel: 'normal' })
+    const result = renderContextBadge({
+      utilization: 0.23,
+      warningLevel: 'normal',
+      remainingTokens: 142_000,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('ctx'), 'should contain ctx label')
     assert.ok(plain.includes('23%'), 'should show 23%')
@@ -17,32 +21,52 @@ describe('renderContextBadge', () => {
   })
 
   it('renders warning level badge', () => {
-    const result = renderContextBadge({ utilization: 0.68, warningLevel: 'warning' })
+    const result = renderContextBadge({
+      utilization: 0.68,
+      warningLevel: 'warning',
+      remainingTokens: 59_000,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('68%'))
     assert.ok(plain.includes('ctx'))
   })
 
   it('renders critical level badge', () => {
-    const result = renderContextBadge({ utilization: 0.89, warningLevel: 'critical' })
+    const result = renderContextBadge({
+      utilization: 0.89,
+      warningLevel: 'critical',
+      remainingTokens: 20_000,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('89%'))
   })
 
   it('renders blocked level badge', () => {
-    const result = renderContextBadge({ utilization: 0.96, warningLevel: 'blocked' })
+    const result = renderContextBadge({
+      utilization: 0.96,
+      warningLevel: 'blocked',
+      remainingTokens: 0,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('96%'))
   })
 
   it('renders 0% utilization correctly', () => {
-    const result = renderContextBadge({ utilization: 0, warningLevel: 'normal' })
+    const result = renderContextBadge({
+      utilization: 0,
+      warningLevel: 'normal',
+      remainingTokens: 184_000,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('0%'))
   })
 
   it('renders 100% utilization correctly', () => {
-    const result = renderContextBadge({ utilization: 1, warningLevel: 'blocked' })
+    const result = renderContextBadge({
+      utilization: 1,
+      warningLevel: 'blocked',
+      remainingTokens: 0,
+    })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('100%'))
   })
@@ -94,6 +118,16 @@ describe('renderContextBadge', () => {
     assert.ok(plain.includes('1.2M left'))
   })
 
+  it('promotes rounded 1000K headroom to million-scale display', () => {
+    const result = renderContextBadge({
+      utilization: 0.12,
+      warningLevel: 'normal',
+      remainingTokens: 999_500,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('1M left'))
+  })
+
   it('shows zero remaining headroom when context is blocked', () => {
     const result = renderContextBadge({
       utilization: 1,
@@ -104,14 +138,12 @@ describe('renderContextBadge', () => {
     assert.ok(plain.includes('0 left'))
   })
 
-  it('keeps the previous badge format when headroom is unavailable', () => {
-    const result = renderContextBadge({ utilization: 0.5, warningLevel: 'warning' })
-    const plain = stripAnsi(result)
-    assert.ok(!plain.includes('left'))
-  })
-
   it('uses correct block characters for utilization', () => {
-    const result = renderContextBadge({ utilization: 0.5, warningLevel: 'warning' })
+    const result = renderContextBadge({
+      utilization: 0.5,
+      warningLevel: 'warning',
+      remainingTokens: 92_000,
+    })
     const plain = stripAnsi(result)
     // 50% → 5 filled blocks out of 10
     const filledCount = (plain.match(/\u2593/g) || []).length

--- a/test/context-badge.test.ts
+++ b/test/context-badge.test.ts
@@ -51,6 +51,7 @@ describe('renderContextBadge', () => {
     const result = renderContextBadge({
       utilization: 0.82,
       warningLevel: 'warning',
+      remainingTokens: 18_000,
       accounting: {
         providerUsageTokens: 70_000,
         estimatedTokens: 12_000,
@@ -59,7 +60,54 @@ describe('renderContextBadge', () => {
     })
     const plain = stripAnsi(result)
     assert.ok(plain.includes('82%'))
+    assert.ok(plain.includes('18K left'))
     assert.ok(plain.includes('usage+est'))
+  })
+
+  it('shows compact remaining context headroom', () => {
+    const result = renderContextBadge({
+      utilization: 0.68,
+      warningLevel: 'warning',
+      remainingTokens: 59_200,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('59K left'))
+  })
+
+  it('shows small remaining context headroom without a suffix', () => {
+    const result = renderContextBadge({
+      utilization: 0.94,
+      warningLevel: 'critical',
+      remainingTokens: 999,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('999 left'))
+  })
+
+  it('shows million-scale remaining context headroom compactly', () => {
+    const result = renderContextBadge({
+      utilization: 0.12,
+      warningLevel: 'normal',
+      remainingTokens: 1_234_000,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('1.2M left'))
+  })
+
+  it('shows zero remaining headroom when context is blocked', () => {
+    const result = renderContextBadge({
+      utilization: 1,
+      warningLevel: 'blocked',
+      remainingTokens: 0,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('0 left'))
+  })
+
+  it('keeps the previous badge format when headroom is unavailable', () => {
+    const result = renderContextBadge({ utilization: 0.5, warningLevel: 'warning' })
+    const plain = stripAnsi(result)
+    assert.ok(!plain.includes('left'))
   })
 
   it('uses correct block characters for utilization', () => {

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -55,6 +55,7 @@ function contextStats(messages: ChatMessage[], effectiveInput = 20_000): Context
     providerUsageTokens: accounting.providerUsageTokens,
     contextWindow: effectiveInput,
     effectiveInput,
+    remainingTokens: Math.max(0, effectiveInput - accounting.totalTokens),
     utilization,
     warningLevel:
       utilization >= 0.95

--- a/test/snip-compact.test.ts
+++ b/test/snip-compact.test.ts
@@ -24,6 +24,7 @@ function contextStats(messages: ChatMessage[], effectiveInput = 20_000): Context
     providerUsageTokens: 0,
     contextWindow: effectiveInput,
     effectiveInput,
+    remainingTokens: Math.max(0, effectiveInput - totalTokens),
     utilization,
     warningLevel:
       utilization >= 0.95

--- a/test/token-estimator.test.ts
+++ b/test/token-estimator.test.ts
@@ -97,6 +97,7 @@ describe('computeContextStats', () => {
     assert.ok(stats.estimatedTokens > 0)
     assert.equal(stats.contextWindow, 200_000)
     assert.equal(stats.effectiveInput, 184_000)
+    assert.equal(stats.remainingTokens, stats.effectiveInput - stats.totalTokens)
   })
 
   it('computes blocked warning level for large messages', () => {
@@ -109,6 +110,7 @@ describe('computeContextStats', () => {
       `expected blocked or critical, got ${stats.warningLevel}`,
     )
     assert.equal(stats.utilization, 1, 'utilization should be capped at 1')
+    assert.equal(stats.remainingTokens, 0)
   })
 
   it('computes warning level for medium messages', () => {
@@ -133,6 +135,7 @@ describe('computeContextStats', () => {
     ]
     const stats = computeContextStats(messages, 'deepseek-chat')
     assert.equal(stats.utilization, 1)
+    assert.equal(stats.remainingTokens, 0)
   })
 })
 


### PR DESCRIPTION
## Summary

This PR adds remaining effective-input headroom to the existing TUI context badge.

The badge already shows context utilization and token accounting source. This change makes the remaining input budget visible as a compact value, for example:

    ctx 68% ▓▓▓▓▓▓▓░░░ 59K left usage+est

Part of #1.

## Why

MiniCode already has model-aware context stats, including `contextWindow`, `outputReserve`, `effectiveInput`, and provider/estimate-based token accounting. However, the TUI only showed utilization percentage, so users could not quickly tell how much usable input budget remained before context pressure became more serious.

Showing remaining effective-input tokens makes long-session context pressure easier to understand without changing the existing compaction behavior.

## Changes

- add `remainingTokens` to `ContextStats`, computed from `effectiveInput - totalTokens`
- show compact remaining headroom in `renderContextBadge`
- keep the badge source label (`usage`, `usage+est`, `est`) unchanged
- align TUI context stats typing with `ContextStats` and update related test fixtures
- add tests for normal, small, million-scale, and blocked headroom display

## Scope

This is intentionally a small visibility follow-up. It does not implement the remaining full context compaction work in #1, and it does not change:

- auto-compact trigger behavior
- provider usage ingestion
- session persistence
- model adapter behavior
- public CLI commands

## Validation

- `npm run check` — passed
- `npm test` — passed, 205 tests
- `npx eslint src/tui/chrome.ts src/utils/token-estimator.ts test/context-badge.test.ts test/token-estimator.test.ts test/session.test.ts test/snip-compact.test.ts` — passed
- `git diff --check` — passed

`npm run lint` currently reports pre-existing `no-undef` errors in `test/run-tests.mjs`, unrelated to this change.

