### PR TITLE
Add MiniMax-M3 and MiniMax-M2.7 model context window rules

### DIFF
--- a/src/utils/model-context.ts
+++ b/src/utils/model-context.ts
@@ -117,6 +117,16 @@ const MODEL_CONTEXT_RULES: ModelContextRule[] = [
     contextWindow: 128_000,
     outputReserve: 4_000,
   },
+  {
+    patterns: ['minimax-m3'],
+    contextWindow: 1_000_000,
+    outputReserve: 16_000,
+  },
+  {
+    patterns: ['minimax-m2.7'],
+    contextWindow: 204_800,
+    outputReserve: 16_000,
+  },
 ]
 
 export function getModelContextWindow(model: string): ModelContextWindow {

--- a/test/model-context.test.ts
+++ b/test/model-context.test.ts
@@ -43,6 +43,25 @@ describe('getModelContextWindow', () => {
     assert.equal(result.outputReserve, 4_000)
   })
 
+  it('returns MiniMax-M3 window with one-million context', () => {
+    const result = getModelContextWindow('MiniMax-M3')
+    assert.equal(result.contextWindow, 1_000_000)
+    assert.equal(result.outputReserve, 16_000)
+    assert.equal(result.effectiveInput, 1_000_000 - 16_000)
+  })
+
+  it('returns MiniMax-M2.7 window', () => {
+    const result = getModelContextWindow('MiniMax-M2.7')
+    assert.equal(result.contextWindow, 204_800)
+    assert.equal(result.outputReserve, 16_000)
+    assert.equal(result.effectiveInput, 204_800 - 16_000)
+  })
+
+  it('does not confuse MiniMax-M3 and MiniMax-M2.7', () => {
+    assert.equal(getModelContextWindow('MiniMax-M3').contextWindow, 1_000_000)
+    assert.equal(getModelContextWindow('MiniMax-M2.7').contextWindow, 204_800)
+  })
+
   it('returns default window for unknown model', () => {
     const result = getModelContextWindow('some-unknown-model-v1')
     assert.equal(result.contextWindow, 128_000)


### PR DESCRIPTION
Reason: The model context registry lacked rules for two model IDs, so both fell back to the 128,000-token unknown-model window instead of their real context sizes.

## What changed

- `src/utils/model-context.ts`: add two context-window rules to `MODEL_CONTEXT_RULES`:
  - `MiniMax-M3` -> 1,000,000-token context window
  - `MiniMax-M2.7` -> 204,800-token context window

  Both use a 16,000-token output reserve, matching the convention already used for the other large-context models in this registry. The lookup is a case-insensitive substring match, and the two patterns are distinct so neither ID resolves to the other.

- `test/model-context.test.ts`: add cases asserting each ID resolves to its context window, output reserve, and effective input, plus a guard that the two IDs are never confused.

Without these rules `getModelContextWindow` returned the 128,000 unknown-model fallback for both IDs, which produced incorrect context-utilization and compaction behavior.

## Checks

- `npm run check` (tsc --noEmit) - passes
- `npm test` - 222 passing, including the new registry cases
- `npx eslint src/utils/model-context.ts test/model-context.test.ts` - clean

(`npm run lint` over the whole tree reports pre-existing `no-undef` errors in `test/run-tests.mjs`, which this change does not touch.)
