### PR TITLE
feat: add minimal multi-sub-agent orchestration

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ In other words, MiniCode is a smaller, more controllable terminal coding assista
 - Full Ink/React rendering stack
 - Bridge / IDE two-way communication
 - Remote session
-- Task swarm / sub-agent orchestration
+- Persistent agent definitions, nested agents, and more advanced task-swarm orchestration (the minimal sub-agent runtime is implemented)
 - LSP
 - Skill marketplace
 - More complex permission modes
@@ -43,6 +43,9 @@ In other words, MiniCode is a smaller, more controllable terminal coding assista
 
 - `src/index.ts`: CLI entry
 - `src/agent-loop.ts`: multi-turn tool-calling loop
+- `src/agents/manager.ts`: in-memory sub-agent lifecycle, concurrency limit, waiting, and cancellation
+- `src/agents/worker-prompt.ts`: minimal read-only worker system prompt
+- `src/tools/sub-agents.ts`: root-only `spawn_agent`, `list_agents`, `wait_agent`, and `close_agent` tools
 - `src/tool.ts`: registration, validation, execution
 - `src/tools/*`: `list_files` / `grep_files` / `read_file` / `write_file` / `edit_file` / `patch_file` / `modify_file` / `run_command` / `web_fetch` / `web_search` / `ask_user` / `load_skill`
 - `src/config.ts`: uses dedicated `~/.mini-code`
@@ -73,6 +76,18 @@ MiniCode keeps runtime state deliberately simple:
 - Local token estimation is only a fallback or a tail estimate after the latest provider usage boundary.
 - Very large tool outputs are moved out of the prompt context and stored under `~/.mini-code/tool-results/`, leaving the model a preview and a path to the full output.
 
+## Multi-agent MVP
+
+The multi-agent implementation is intentionally a small, readable loop:
+
+1. The root calls `spawn_agent` to create an in-memory worker. Each worker has its own message array and `AbortController`.
+2. Workers share the model adapter with the root, but every model request receives an explicit tool list. Workers only get file search/read, skill loading, and web research tools.
+3. Workers cannot edit files, run commands, ask the user, or create more agents. The root owns every code change.
+4. At most 3 workers may be `running`. `wait_agent` collects reports; `close_agent` aborts an active model request and prevents another tool or model step.
+5. While workers run, the TUI footer shows `SUB-AGENTS n/3 RUNNING`. The foreground interaction model remains unchanged.
+
+This MVP does not persist workers, load `.claude/agents`, support nesting, isolate worktrees, or allow live user steering. Its teaching focus is the four essential ideas: isolated context, restricted tools, background promises, and lifecycle control.
+
 ## Why it is good for learning
 
 One strength of MiniCode is that it delivers Claude Code–like behavior and core architectural ideas in a much lighter implementation.
@@ -81,6 +96,7 @@ That makes it well suited to:
 
 - Learning the basic pieces of a terminal coding agent
 - Studying tool-calling loops
+- Understanding root/worker context isolation, tool isolation, and cancellation
 - Understanding permission approval and file review flows
 - Seeing how skills and external MCP tools can be added without a heavy plugin platform
 - Seeing a lightweight Claude Code-style distinction between foreground tool execution and background shell tasks

--- a/ARCHITECTURE_ZH.md
+++ b/ARCHITECTURE_ZH.md
@@ -31,7 +31,7 @@ MiniCode 优先保留这些能力：
 - 完整 Ink/React 渲染栈
 - bridge / IDE 双向通信
 - remote session
-- task swarm / sub-agent 编排
+- 持久化 agent 定义、嵌套 agent 与更复杂的 task swarm 编排（最小 sub-agent runtime 已实现）
 - LSP
 - skill marketplace
 - 复杂 permission 模式
@@ -45,6 +45,9 @@ MiniCode 优先保留这些能力：
 
 - `src/index.ts`: CLI 入口
 - `src/agent-loop.ts`: 多轮工具调用循环
+- `src/agents/manager.ts`: 内存态 sub-agent 生命周期、并发上限、等待与取消
+- `src/agents/worker-prompt.ts`: 只读 worker 的最小系统提示词
+- `src/tools/sub-agents.ts`: root agent 使用的 `spawn_agent` / `list_agents` / `wait_agent` / `close_agent`
 - `src/tool.ts`: 注册、校验、执行
 - `src/tools/*`: `list_files` / `grep_files` / `read_file` / `write_file` / `edit_file` / `patch_file` / `modify_file` / `run_command` / `web_fetch` / `web_search` / `ask_user` / `load_skill`
 - `src/config.ts`: 使用独立的 `~/.mini-code`
@@ -75,6 +78,18 @@ MiniCode 的运行时状态有意保持简单：
 - 本地 token 估算只作为 provider usage 缺失时的 fallback，或作为最新 provider usage boundary 之后新增消息的 tail estimate。
 - 超大工具输出会被移出 prompt context，保存到 `~/.mini-code/tool-results/`，模型只看到预览和完整输出路径。
 
+## Multi-agent MVP
+
+MiniCode 的 multi-agent 实现刻意保持为一个可读的最小闭环：
+
+1. root agent 调用 `spawn_agent` 创建内存态 worker；每个 worker 有独立的消息数组和 `AbortController`。
+2. worker 与 root 共用同一个模型适配器，但每次模型请求都显式传入自己的工具列表。worker 只拥有 `list_files`、`grep_files`、`read_file`、`load_skill`、`web_fetch` 和 `web_search`。
+3. worker 不能写文件、执行命令、询问用户或继续创建 agent；所有代码修改都由 root agent 完成。
+4. 同时最多有 3 个 `running` worker。`wait_agent` 收集报告，`close_agent` 会取消正在进行的模型请求，并阻止 worker 进入下一个工具或模型步骤。
+5. TUI 底栏在 worker 运行时显示醒目的 `SUB-AGENTS n/3 RUNNING` 状态。主 TUI 仍保持单前台回合的交互模型。
+
+这个 MVP 暂不持久化 worker，不读取 `.claude/agents`，不允许嵌套 agent，也不实现工作树隔离或用户实时 steering。这样可以把教学重点放在“独立上下文 + 受限工具集 + 后台 Promise + 生命周期控制”四个核心概念上。
+
 ## 为什么适合学习
 
 MiniCode 的一个优势，是用更轻量的实现方式，提供了类 Claude Code 的功能体验和核心架构思路。
@@ -83,6 +98,7 @@ MiniCode 的一个优势，是用更轻量的实现方式，提供了类 Claude 
 
 - 学习 terminal coding agent 的基本组成
 - 研究 tool-calling loop
+- 理解 root/worker 的上下文隔离、工具隔离和取消机制
 - 理解权限审批和文件 review 流程
 - 理解如何在不引入重型插件平台的情况下接入 skills 和 MCP
 - 理解一种更接近 Claude Code 的“前台工具执行 / 后台 shell task”区分方式

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ MiniCode is a good fit if you want:
 ## Core Capabilities
 
 - Multi-step tool execution in a single turn, forming a `model -> tool -> model` loop.
+- Up to 3 concurrent read-only sub-agents; the root agent owns all code changes and can wait for or close workers.
 - Full-screen terminal UI with input history, transcript scrolling, slash command menu, and approval flows.
 - Per-project session persistence with resume, rename, fork, and compact commands.
 - Provider-usage-first context stats with tail estimates, auto-compact, context collapse, and snip compact.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,6 +123,7 @@ MiniCode 适合你，如果你想要：
 ## 核心能力
 
 - 单轮支持多步工具执行，形成 `model -> tool -> model` 闭环。
+- 支持最多 3 个并发的只读 sub-agent；root agent 统一修改代码，并可等待或主动关闭 worker。
 - 提供全屏终端交互界面，支持输入历史、transcript 滚动、slash 命令菜单和审批交互。
 - 会话按项目隔离持久化，支持恢复、重命名、分叉和压缩。
 - 上下文统计优先使用 provider usage，并支持 tail estimate、自动压缩、上下文折叠和裁剪压缩。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,9 +93,9 @@ This should stay simple and should not become a heavyweight planning subsystem.
 
 ### 8. `.claude/agents` and sub-agent support
 
-This is an important capability, but it also adds complexity.
+The minimal version is implemented: the root agent can run up to 3 read-only workers concurrently and manage them with `list_agents`, `wait_agent`, and `close_agent`. Workers have isolated context and a restricted tool set; the root remains the only code editor.
 
-It is worth doing after the core runtime is more stable.
+Future work may add persistent `.claude/agents` definitions, richer scheduling, and more detailed progress reporting. Nested agents and worktree isolation are outside the current teaching MVP.
 
 ### 9. Expand the core toolset selectively
 

--- a/ROADMAP_ZH.md
+++ b/ROADMAP_ZH.md
@@ -93,9 +93,9 @@ MiniCode 当前已经能接 Anthropic 风格接口和部分兼容供应商，但
 
 ### 8. `.claude/agents` 与 sub-agent 支持
 
-这是一个重要能力，但复杂度也会明显上升。
+最小版本已经实现：root agent 可并发启动最多 3 个只读 worker，并通过 `list_agents`、`wait_agent` 和 `close_agent` 管理生命周期。worker 使用独立上下文和受限工具集，所有代码修改仍由 root 完成。
 
-更适合在核心 runtime 更稳定之后推进。
+后续可继续支持 `.claude/agents` 持久化定义、更多调度策略和更细的进度展示；嵌套 agent 与工作树隔离不属于当前教学 MVP。
 
 ### 9. 有选择地扩充核心工具集
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,4 +59,10 @@ export default [
       '@typescript-eslint/no-unused-vars': 'off',
     },
   },
+  {
+    files: ['test/**/*.mjs'],
+    languageOptions: {
+      globals: nodeGlobals,
+    },
+  },
 ]

--- a/src/abort.ts
+++ b/src/abort.ts
@@ -1,0 +1,34 @@
+export function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Operation aborted')
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw abortError(signal)
+  }
+}
+
+export function abortableDelay(
+  milliseconds: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal)
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(finish, Math.max(0, milliseconds))
+
+    function finish(): void {
+      signal?.removeEventListener('abort', cancel)
+      resolve()
+    }
+
+    function cancel(): void {
+      clearTimeout(timer)
+      reject(abortError(signal!))
+    }
+
+    signal?.addEventListener('abort', cancel, { once: true })
+  })
+}

--- a/src/agent-loop.ts
+++ b/src/agent-loop.ts
@@ -15,6 +15,7 @@ import {
   type ContextCollapseResult,
   type ContextCollapseState,
 } from './compact/context-collapse.js'
+import { throwIfAborted } from './abort.js'
 import {
   snipCompactConversation,
   type SnipCompactResult,
@@ -127,6 +128,7 @@ export async function runAgentTurn(args: {
   onContextStats?: (stats: import('./utils/token-estimator.js').ContextStats) => void
   contentReplacementState?: ContentReplacementState
   contextCollapseState?: ContextCollapseState
+  signal?: AbortSignal
 }): Promise<ChatMessage[]> {
   const maxSteps = args.maxSteps
   const modelName = args.modelName ?? ''
@@ -172,6 +174,7 @@ export async function runAgentTurn(args: {
   }
 
   for (let step = 0; maxSteps == null || step < maxSteps; step++) {
+    throwIfAborted(args.signal)
     let latestStats: import('./utils/token-estimator.js').ContextStats | null = null
     let modelMessages = messages
 
@@ -235,7 +238,10 @@ export async function runAgentTurn(args: {
       }
     }
 
-    const next = await args.model.next(modelMessages)
+    const next = await args.model.next(modelMessages, {
+      tools: args.tools.list(),
+      signal: args.signal,
+    })
 
     if (next.type === 'assistant') {
       const isEmpty = isEmptyAssistantResponse(next.content)
@@ -378,6 +384,7 @@ export async function runAgentTurn(args: {
     }> = []
 
     for (const call of next.calls) {
+      throwIfAborted(args.signal)
       args.onToolStart?.(call.toolName, call.input)
       const result = await args.tools.execute(
         call.toolName,

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -1,0 +1,190 @@
+import { runAgentTurn } from '../agent-loop.js'
+import type { ToolRegistry } from '../tool.js'
+import type { ChatMessage, ModelAdapter } from '../types.js'
+import {
+  MAX_SUB_AGENTS,
+  MAX_SUB_AGENT_STEPS,
+  type SubAgentSnapshot,
+  type WaitForSubAgentsResult,
+} from './types.js'
+import { buildSubAgentPrompt } from './worker-prompt.js'
+
+type SubAgentRecord = SubAgentSnapshot & {
+  controller: AbortController
+  completion: Promise<void>
+}
+
+type SubAgentManagerOptions = {
+  model: ModelAdapter
+  tools: ToolRegistry
+  cwd: string
+}
+
+export class SubAgentManager {
+  readonly maxConcurrent = MAX_SUB_AGENTS
+
+  private readonly records = new Map<string, SubAgentRecord>()
+  private readonly listeners = new Set<() => void>()
+  private nextId = 1
+
+  constructor(private readonly options: SubAgentManagerOptions) {}
+
+  spawn(task: string): SubAgentSnapshot {
+    const normalizedTask = task.trim()
+    if (!normalizedTask) {
+      throw new Error('Sub-agent task cannot be empty')
+    }
+    if (this.runningCount >= this.maxConcurrent) {
+      throw new Error(
+        `At most ${this.maxConcurrent} sub-agents may run at the same time`,
+      )
+    }
+
+    const record: SubAgentRecord = {
+      id: `agent_${this.nextId++}`,
+      task: normalizedTask,
+      status: 'running',
+      startedAt: Date.now(),
+      controller: new AbortController(),
+      completion: Promise.resolve(),
+    }
+    this.records.set(record.id, record)
+    record.completion = this.run(record)
+    this.notify()
+    return this.snapshot(record)
+  }
+
+  get runningCount(): number {
+    return [...this.records.values()].filter(
+      record => record.status === 'running',
+    ).length
+  }
+
+  list(): SubAgentSnapshot[] {
+    return [...this.records.values()].map(record => this.snapshot(record))
+  }
+
+  async wait(
+    agentIds: string[],
+    timeoutMs = 30_000,
+  ): Promise<WaitForSubAgentsResult> {
+    const records = agentIds.map(id => this.requireRecord(id))
+    const running = records.filter(record => record.status === 'running')
+    if (running.length === 0) {
+      return {
+        timedOut: false,
+        agents: records.map(record => this.snapshot(record)),
+      }
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const completed = Promise.all(running.map(record => record.completion)).then(
+      () => false,
+    )
+    const timedOut = await Promise.race([
+      completed,
+      new Promise<true>(resolve => {
+        timer = setTimeout(() => resolve(true), Math.max(0, timeoutMs))
+      }),
+    ])
+    if (timer) {
+      clearTimeout(timer)
+    }
+
+    return {
+      timedOut,
+      agents: records.map(record => this.snapshot(record)),
+    }
+  }
+
+  async close(agentId: string): Promise<SubAgentSnapshot> {
+    const record = this.requireRecord(agentId)
+    if (record.status === 'running') {
+      record.status = 'closed'
+      record.controller.abort(new Error('Sub-agent closed by root agent'))
+      this.notify()
+      await record.completion
+    }
+    return this.snapshot(record)
+  }
+
+  async closeAll(): Promise<void> {
+    const runningIds = [...this.records.values()]
+      .filter(record => record.status === 'running')
+      .map(record => record.id)
+    await Promise.all(runningIds.map(id => this.close(id)))
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private async run(record: SubAgentRecord): Promise<void> {
+    try {
+      const messages: ChatMessage[] = [
+        {
+          role: 'system',
+          content: await buildSubAgentPrompt(this.options.cwd),
+        },
+        { role: 'user', content: record.task },
+      ]
+      const result = await runAgentTurn({
+        model: this.options.model,
+        tools: this.options.tools,
+        messages,
+        cwd: this.options.cwd,
+        maxSteps: MAX_SUB_AGENT_STEPS,
+        signal: record.controller.signal,
+      })
+
+      if (record.status !== 'closed') {
+        record.status = 'completed'
+        record.result = this.lastAssistantMessage(result)
+      }
+    } catch (error) {
+      if (record.status !== 'closed') {
+        record.status = 'failed'
+        record.error = error instanceof Error ? error.message : String(error)
+      }
+    } finally {
+      record.finishedAt = Date.now()
+      this.notify()
+    }
+  }
+
+  private lastAssistantMessage(messages: ChatMessage[]): string {
+    const message = [...messages]
+      .reverse()
+      .find(candidate => candidate.role === 'assistant')
+    return message?.role === 'assistant'
+      ? message.content
+      : 'Sub-agent finished without an assistant report.'
+  }
+
+  private requireRecord(agentId: string): SubAgentRecord {
+    const record = this.records.get(agentId)
+    if (!record) {
+      throw new Error(`Unknown sub-agent: ${agentId}`)
+    }
+    return record
+  }
+
+  private snapshot(record: SubAgentRecord): SubAgentSnapshot {
+    return {
+      id: record.id,
+      task: record.task,
+      status: record.status,
+      startedAt: record.startedAt,
+      finishedAt: record.finishedAt,
+      result: record.result,
+      error: record.error,
+    }
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener()
+    }
+  }
+}

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,23 @@
+export const MAX_SUB_AGENTS = 3
+export const MAX_SUB_AGENT_STEPS = 20
+
+export type SubAgentStatus =
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'closed'
+
+export type SubAgentSnapshot = {
+  id: string
+  task: string
+  status: SubAgentStatus
+  startedAt: number
+  finishedAt?: number
+  result?: string
+  error?: string
+}
+
+export type WaitForSubAgentsResult = {
+  timedOut: boolean
+  agents: SubAgentSnapshot[]
+}

--- a/src/agents/worker-prompt.ts
+++ b/src/agents/worker-prompt.ts
@@ -1,0 +1,20 @@
+import { loadMemory } from '../memory.js'
+
+export async function buildSubAgentPrompt(cwd: string): Promise<string> {
+  const parts = [
+    'You are a read-only sub-agent helping the root coding agent.',
+    `Current cwd: ${cwd}`,
+    'Investigate only the task assigned in the user message.',
+    'Use search and read tools to gather concrete evidence.',
+    'You cannot modify files, run commands, ask the user questions, or create other agents.',
+    'Return a concise report with relevant file paths, line references, findings, and a recommended next step for the root agent.',
+    'Do not claim to have changed code. The root agent is the only agent allowed to make edits.',
+  ]
+
+  const memory = await loadMemory(cwd)
+  if (memory) {
+    parts.push(memory)
+  }
+
+  return parts.join('\n\n')
+}

--- a/src/anthropic-adapter.ts
+++ b/src/anthropic-adapter.ts
@@ -2,6 +2,7 @@ import type { ToolRegistry } from './tool.js'
 import type {
   ChatMessage,
   ModelAdapter,
+  ModelRequestOptions,
   ProviderThinkingBlock,
   ProviderUsage,
   StepDiagnostics,
@@ -10,6 +11,7 @@ import type {
 import type { RuntimeConfig } from './config.js'
 import { resolveMaxOutputTokens } from './utils/context.js'
 import { buildAnthropicSnipBoundaryText } from './compact/snipCompact.js'
+import { abortableDelay, throwIfAborted } from './abort.js'
 
 const DEFAULT_MAX_RETRIES = 4
 const BASE_RETRY_DELAY_MS = 500
@@ -31,12 +33,6 @@ type AnthropicUsage = {
   output_tokens?: number
   cache_creation_input_tokens?: number
   cache_read_input_tokens?: number
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => {
-    setTimeout(resolve, Math.max(0, ms))
-  })
 }
 
 function getRetryLimit(): number {
@@ -307,7 +303,11 @@ export class AnthropicModelAdapter implements ModelAdapter {
     private readonly getRuntimeConfig: () => Promise<RuntimeConfig>,
   ) {}
 
-  async next(messages: ChatMessage[]) {
+  async next(
+    messages: ChatMessage[],
+    options: ModelRequestOptions = {},
+  ) {
+    throwIfAborted(options.signal)
     const runtime = await this.getRuntimeConfig()
     const payload = toAnthropicMessages(messages)
     const url = `${runtime.baseUrl.replace(/\/$/, '')}/v1/messages`
@@ -331,7 +331,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
       model: runtime.model,
       system: payload.system,
       messages: payload.messages,
-      tools: this.tools.list().map(tool => ({
+      tools: (options.tools ?? this.tools.list()).map(tool => ({
         name: tool.name,
         description: tool.description,
         input_schema: tool.inputSchema,
@@ -346,6 +346,7 @@ export class AnthropicModelAdapter implements ModelAdapter {
         method: 'POST',
         headers,
         body: JSON.stringify(requestBody),
+        signal: options.signal,
       })
       if (response.ok) {
         break
@@ -354,7 +355,10 @@ export class AnthropicModelAdapter implements ModelAdapter {
         break
       }
       const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'))
-      await sleep(getRetryDelayMs(attempt + 1, retryAfterMs))
+      await abortableDelay(
+        getRetryDelayMs(attempt + 1, retryAfterMs),
+        options.signal,
+      )
     }
 
     if (!response) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,13 @@ import { summarizeMcpServers } from './mcp-status.js'
 import { MockModelAdapter } from './mock-model.js'
 import { PermissionManager } from './permissions.js'
 import { buildSystemPrompt } from './prompt.js'
-import { createDefaultToolRegistry, hydrateMcpTools } from './tools/index.js'
+import {
+  createDefaultToolRegistry,
+  hydrateMcpTools,
+  SUB_AGENT_TOOL_NAMES,
+} from './tools/index.js'
+import { createSubAgentTools } from './tools/sub-agents.js'
+import { SubAgentManager } from './agents/manager.js'
 import type { ChatMessage } from './types.js'
 import { renderBanner } from './ui.js'
 import { runTtyApp } from './tty-app.js'
@@ -82,12 +88,19 @@ async function main(): Promise<void> {
     process.env.MINI_CODE_MODEL_MODE === 'mock'
       ? new MockModelAdapter()
       : new AnthropicModelAdapter(tools, loadRuntimeConfig)
+  const subAgents = new SubAgentManager({
+    model,
+    tools: tools.subset(SUB_AGENT_TOOL_NAMES),
+    cwd,
+  })
+  tools.addTools(createSubAgentTools(subAgents))
   let messages: ChatMessage[] = [
     {
       role: 'system',
       content: await buildSystemPrompt(cwd, permissions.getSummary(), {
         skills: tools.getSkills(),
         mcpServers: tools.getMcpServers(),
+        subAgents: { maxConcurrent: subAgents.maxConcurrent },
       }),
     },
   ]
@@ -100,6 +113,7 @@ async function main(): Promise<void> {
       content: await buildSystemPrompt(cwd, permissions.getSummary(), {
         skills: tools.getSkills(),
         mcpServers: tools.getMcpServers(),
+        subAgents: { maxConcurrent: subAgents.maxConcurrent },
       }),
     }
   }
@@ -123,6 +137,7 @@ async function main(): Promise<void> {
         runtime,
         tools,
         model,
+        subAgents,
         messages,
         cwd,
         permissions,
@@ -278,6 +293,7 @@ async function main(): Promise<void> {
       // Ignore double-close during EOF teardown.
     }
   } finally {
+    await subAgents.closeAll()
     await mcpHydration
     await tools.dispose()
   }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -8,6 +8,7 @@ export async function buildSystemPrompt(
   extras?: {
     skills?: SkillSummary[]
     mcpServers?: McpServerSummary[]
+    subAgents?: { maxConcurrent: number }
   },
 ): Promise<string> {
   const parts = [
@@ -32,6 +33,17 @@ export async function buildSystemPrompt(
 
   if (permissionSummary.length > 0) {
     parts.push(`Permission context:\n${permissionSummary.join('\n')}`)
+  }
+
+  if (extras?.subAgents) {
+    parts.push([
+      'Sub-agent coordination:',
+      `- You may run at most ${extras.subAgents.maxConcurrent} read-only sub-agents concurrently with spawn_agent.`,
+      '- Delegate only independent investigation tasks. Sub-agents have separate message histories and cannot modify code or spawn more agents.',
+      '- You are the root agent and the only agent allowed to edit files or run commands that change the project.',
+      '- Use wait_agent to collect reports. Use close_agent when an agent is looping, no longer useful, or should stop consuming model calls.',
+      '- Before giving a final answer, collect the reports you need and close any sub-agents that are still running.',
+    ].join('\n'))
   }
 
   const skills = extras?.skills ?? []

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -58,6 +58,13 @@ export class ToolRegistry {
     return this.toolsStore
   }
 
+  subset(names: readonly string[]): ToolRegistry {
+    const allowedNames = new Set(names)
+    return new ToolRegistry(
+      this.toolsStore.filter(tool => allowedNames.has(tool.name)),
+    )
+  }
+
   getSkills(): SkillSummary[] {
     return this.metadataStore.skills ?? []
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -16,6 +16,15 @@ import { webFetchTool } from './web-fetch.js'
 import { webSearchTool } from './web-search.js'
 import { writeFileTool } from './write-file.js'
 
+export const SUB_AGENT_TOOL_NAMES = [
+  'list_files',
+  'grep_files',
+  'read_file',
+  'load_skill',
+  'web_fetch',
+  'web_search',
+] as const
+
 function summarizeServerEndpoint(config: McpServerConfig): string {
   const remoteUrl = config.url?.trim()
   if (remoteUrl) return remoteUrl

--- a/src/tools/sub-agents.ts
+++ b/src/tools/sub-agents.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod'
+import type { SubAgentManager } from '../agents/manager.js'
+import type { SubAgentSnapshot } from '../agents/types.js'
+import type { ToolDefinition } from '../tool.js'
+
+function displayAgent(agent: SubAgentSnapshot): Record<string, unknown> {
+  return {
+    id: agent.id,
+    task: agent.task,
+    status: agent.status,
+    result: agent.result,
+    error: agent.error,
+  }
+}
+
+export function createSubAgentTools(
+  manager: SubAgentManager,
+): ToolDefinition<unknown>[] {
+  const spawnAgentTool: ToolDefinition<{ task: string }> = {
+    name: 'spawn_agent',
+    description:
+      'Start a read-only sub-agent for one independent research task. It runs in the background and cannot edit code. At most 3 sub-agents may run concurrently.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        task: {
+          type: 'string',
+          description: 'A specific, self-contained investigation task.',
+        },
+      },
+      required: ['task'],
+    },
+    schema: z.object({ task: z.string().min(1) }),
+    async run(input) {
+      const agent = manager.spawn(input.task)
+      return {
+        ok: true,
+        output: JSON.stringify({
+          agent: displayAgent(agent),
+          running: manager.runningCount,
+          max_concurrent: manager.maxConcurrent,
+        }, null, 2),
+      }
+    },
+  }
+
+  const listAgentsTool: ToolDefinition<Record<string, never>> = {
+    name: 'list_agents',
+    description:
+      'List all sub-agents created in this MiniCode process and their current status.',
+    inputSchema: { type: 'object', properties: {} },
+    schema: z.object({}),
+    async run() {
+      return {
+        ok: true,
+        output: JSON.stringify({
+          running: manager.runningCount,
+          max_concurrent: manager.maxConcurrent,
+          agents: manager.list().map(displayAgent),
+        }, null, 2),
+      }
+    },
+  }
+
+  const waitAgentTool: ToolDefinition<{
+    agent_ids: string[]
+    timeout_ms?: number
+  }> = {
+    name: 'wait_agent',
+    description:
+      'Wait for selected sub-agents to finish and return their reports. A timeout returns their latest states without closing them.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Sub-agent IDs returned by spawn_agent.',
+        },
+        timeout_ms: {
+          type: 'number',
+          description: 'Maximum wait time in milliseconds. Defaults to 30000.',
+        },
+      },
+      required: ['agent_ids'],
+    },
+    schema: z.object({
+      agent_ids: z.array(z.string().min(1)).min(1),
+      timeout_ms: z.number().int().min(0).max(120_000).optional(),
+    }),
+    async run(input) {
+      const result = await manager.wait(input.agent_ids, input.timeout_ms)
+      return {
+        ok: true,
+        output: JSON.stringify({
+          timed_out: result.timedOut,
+          agents: result.agents.map(displayAgent),
+        }, null, 2),
+      }
+    },
+  }
+
+  const closeAgentTool: ToolDefinition<{ agent_id: string }> = {
+    name: 'close_agent',
+    description:
+      'Stop one running sub-agent. Use this when it is looping, no longer needed, or should not continue consuming model calls.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agent_id: {
+          type: 'string',
+          description: 'The sub-agent ID to stop.',
+        },
+      },
+      required: ['agent_id'],
+    },
+    schema: z.object({ agent_id: z.string().min(1) }),
+    async run(input) {
+      const agent = await manager.close(input.agent_id)
+      return {
+        ok: true,
+        output: JSON.stringify({ agent: displayAgent(agent) }, null, 2),
+      }
+    },
+  }
+
+  return [spawnAgentTool, listAgentsTool, waitAgentTool, closeAgentTool]
+}

--- a/src/tty-app.ts
+++ b/src/tty-app.ts
@@ -63,6 +63,7 @@ import type { RuntimeConfig } from './config.js'
 import type { ToolRegistry } from './tool.js'
 import type { ChatMessage, CompressionResult, ModelAdapter } from './types.js'
 import type { ContextStats } from './utils/token-estimator.js'
+import type { SubAgentManager } from './agents/manager.js'
 import { computeContextStats } from './utils/token-estimator.js'
 import { manualCompact } from './compact/manual-compact.js'
 import { snipCompactConversation } from './compact/snipCompact.js'
@@ -81,6 +82,7 @@ type TtyAppArgs = {
   runtime: RuntimeConfig | null
   tools: ToolRegistry
   model: ModelAdapter
+  subAgents: SubAgentManager
   messages: ChatMessage[]
   cwd: string
   permissions: PermissionManager
@@ -774,6 +776,8 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
         backgroundTasks,
         state.compressionStatus,
         state.statusAnimationFrame,
+        undefined,
+        renderSubAgentFooter(args.subAgents),
       ),
     )
     renderTerminalFrame(frame.join('\n'))
@@ -811,6 +815,8 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
         backgroundTasks,
         state.compressionStatus,
         state.statusAnimationFrame,
+        undefined,
+        renderSubAgentFooter(args.subAgents),
       ),
     )
     renderTerminalFrame(frame.join('\n'))
@@ -846,9 +852,15 @@ function renderScreen(args: TtyAppArgs, state: ScreenState): void {
       state.compressionStatus,
       state.statusAnimationFrame,
       renderFooterStatus(state),
+      renderSubAgentFooter(args.subAgents),
     ),
   )
   renderTerminalFrame(frame.join('\n'))
+}
+
+function renderSubAgentFooter(manager: SubAgentManager): string | undefined {
+  if (manager.runningCount === 0) return undefined
+  return `\x1b[1m\x1b[35m● SUB-AGENTS ${manager.runningCount}/${manager.maxConcurrent} RUNNING\x1b[0m`
 }
 
 function createRenderScheduler(renderNow: () => void): () => void {
@@ -870,6 +882,7 @@ async function refreshSystemPrompt(args: TtyAppArgs): Promise<void> {
     content: await buildSystemPrompt(args.cwd, args.permissions.getSummary(), {
       skills: args.tools.getSkills(),
       mcpServers: args.tools.getMcpServers(),
+      subAgents: { maxConcurrent: args.subAgents.maxConcurrent },
     }),
   }
 }
@@ -1693,6 +1706,7 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
   const renderNow = () => renderScreen(permissionArgs, state)
   let scheduleRender = renderNow
   scheduleRender = createRenderScheduler(renderNow)
+  const unsubscribeSubAgents = permissionArgs.subAgents.subscribe(scheduleRender)
   await permissionArgs.permissions.whenReady()
   if (
     permissionArgs.messages.length === 0 ||
@@ -1776,6 +1790,7 @@ export async function runTtyApp(args: TtyAppArgs): Promise<void> {
       clearInterval(statusAnimationTimer)
       clearInterval(welcomeAnimationTimer)
       clearInterval(inputHintTimer)
+      unsubscribeSubAgents()
       process.stdin.off('data', onData)
       process.stdin.off('end', onEnd)
       process.stdin.off('close', onClose)

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,8 +85,22 @@ export type AgentStep =
       usage?: ProviderUsage
     }
 
+export type ModelToolDefinition = {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+export type ModelRequestOptions = {
+  tools?: ModelToolDefinition[]
+  signal?: AbortSignal
+}
+
 export interface ModelAdapter {
-  next(messages: ChatMessage[]): Promise<AgentStep>
+  next(
+    messages: ChatMessage[],
+    options?: ModelRequestOptions,
+  ): Promise<AgentStep>
 }
 
 export type CompressionResult = {

--- a/test/model-request-options.test.ts
+++ b/test/model-request-options.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { AnthropicModelAdapter } from '../src/anthropic-adapter.js'
+import { ToolRegistry } from '../src/tool.js'
+import type { RuntimeConfig } from '../src/config.js'
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+function runtime(): RuntimeConfig {
+  return {
+    model: 'test-model',
+    baseUrl: 'https://example.test',
+    authToken: 'test-token',
+    mcpServers: {},
+    sourceSummary: 'test',
+  }
+}
+
+describe('model request options', () => {
+  it('uses the per-request tool list instead of the adapter default', async () => {
+    let requestBody: {
+      tools?: Array<{ name: string }>
+    } = {}
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body ?? '{}'))
+      return new Response(JSON.stringify({
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: '<final>done' }],
+      }), { status: 200 })
+    }) as typeof fetch
+    const adapter = new AnthropicModelAdapter(
+      new ToolRegistry([]),
+      async () => runtime(),
+    )
+
+    await adapter.next(
+      [{ role: 'user', content: 'hello' }],
+      {
+        tools: [{
+          name: 'read_only_tool',
+          description: 'Read only',
+          inputSchema: { type: 'object', properties: {} },
+        }],
+      },
+    )
+
+    assert.deepEqual(requestBody.tools?.map(tool => tool.name), ['read_only_tool'])
+  })
+
+  it('passes AbortSignal through to fetch', async () => {
+    let fetchSignal: AbortSignal | null | undefined
+    let markStarted: (() => void) | undefined
+    const started = new Promise<void>(resolve => {
+      markStarted = resolve
+    })
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      fetchSignal = init?.signal
+      markStarted?.()
+      return await new Promise<Response>((_resolve, reject) => {
+        const rejectForAbort = () => reject(new Error('fetch aborted'))
+        if (fetchSignal?.aborted) {
+          rejectForAbort()
+          return
+        }
+        fetchSignal?.addEventListener('abort', rejectForAbort, { once: true })
+      })
+    }) as typeof fetch
+    const adapter = new AnthropicModelAdapter(
+      new ToolRegistry([]),
+      async () => runtime(),
+    )
+    const controller = new AbortController()
+    const request = adapter.next(
+      [{ role: 'user', content: 'hello' }],
+      { signal: controller.signal },
+    )
+
+    await started
+    controller.abort(new Error('closed'))
+
+    await assert.rejects(request, /fetch aborted/)
+    assert.equal(fetchSignal, controller.signal)
+  })
+})

--- a/test/sub-agents.test.ts
+++ b/test/sub-agents.test.ts
@@ -1,0 +1,205 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { SubAgentManager } from '../src/agents/manager.js'
+import { MAX_SUB_AGENTS } from '../src/agents/types.js'
+import { ToolRegistry, type ToolDefinition } from '../src/tool.js'
+import { SUB_AGENT_TOOL_NAMES } from '../src/tools/index.js'
+import { createSubAgentTools } from '../src/tools/sub-agents.js'
+import type {
+  AgentStep,
+  ChatMessage,
+  ModelAdapter,
+  ModelRequestOptions,
+} from '../src/types.js'
+
+function testTool(name: string): ToolDefinition<Record<string, never>> {
+  return {
+    name,
+    description: `${name} test tool`,
+    inputSchema: { type: 'object', properties: {} },
+    schema: z.object({}),
+    async run() {
+      return { ok: true, output: name }
+    },
+  }
+}
+
+describe('SubAgentManager', () => {
+  it('exposes the four root orchestration tools', async () => {
+    const model: ModelAdapter = {
+      async next(): Promise<AgentStep> {
+        return { type: 'assistant', content: 'worker report' }
+      },
+    }
+    const manager = new SubAgentManager({
+      model,
+      tools: new ToolRegistry([]),
+      cwd: process.cwd(),
+    })
+    const tools = new ToolRegistry(createSubAgentTools(manager))
+
+    assert.deepEqual(
+      tools.list().map(tool => tool.name),
+      ['spawn_agent', 'list_agents', 'wait_agent', 'close_agent'],
+    )
+    const spawned = await tools.execute(
+      'spawn_agent',
+      { task: 'inspect the parser' },
+      { cwd: process.cwd() },
+    )
+    assert.equal(spawned.ok, true)
+    const spawnedOutput = JSON.parse(spawned.output) as {
+      agent: { id: string }
+    }
+    const waited = await tools.execute(
+      'wait_agent',
+      { agent_ids: [spawnedOutput.agent.id] },
+      { cwd: process.cwd() },
+    )
+    const waitedOutput = JSON.parse(waited.output) as {
+      agents: Array<Record<string, unknown>>
+    }
+
+    assert.equal(waited.ok, true)
+    assert.deepEqual(waitedOutput.agents, [{
+      id: spawnedOutput.agent.id,
+      task: 'inspect the parser',
+      status: 'completed',
+      result: 'worker report',
+    }])
+  })
+
+  it('runs at most three isolated workers with only the read-only tool set', async () => {
+    const requests: Array<{
+      messages: ChatMessage[]
+      options?: ModelRequestOptions
+    }> = []
+    const model: ModelAdapter = {
+      async next(messages, options): Promise<AgentStep> {
+        requests.push({ messages, options })
+        const task = messages.findLast(message => message.role === 'user')
+        return {
+          type: 'assistant',
+          content: task?.role === 'user' ? `report: ${task.content}` : 'report',
+        }
+      },
+    }
+    const rootTools = new ToolRegistry([
+      ...SUB_AGENT_TOOL_NAMES.map(testTool),
+      testTool('write_file'),
+      testTool('run_command'),
+      testTool('spawn_agent'),
+    ])
+    const manager = new SubAgentManager({
+      model,
+      tools: rootTools.subset(SUB_AGENT_TOOL_NAMES),
+      cwd: process.cwd(),
+    })
+
+    const agents = ['one', 'two', 'three'].map(task => manager.spawn(task))
+    assert.equal(manager.runningCount, MAX_SUB_AGENTS)
+    assert.throws(
+      () => manager.spawn('four'),
+      /At most 3 sub-agents/,
+    )
+
+    const result = await manager.wait(agents.map(agent => agent.id))
+    assert.equal(result.timedOut, false)
+    assert.deepEqual(
+      result.agents.map(agent => agent.status),
+      ['completed', 'completed', 'completed'],
+    )
+    assert.deepEqual(
+      result.agents.map(agent => agent.result),
+      ['report: one', 'report: two', 'report: three'],
+    )
+    assert.equal(requests.length, 3)
+
+    const expectedTools = [...SUB_AGENT_TOOL_NAMES]
+    for (const request of requests) {
+      assert.equal(
+        request.messages.filter(message => message.role === 'user').length,
+        1,
+      )
+      assert.deepEqual(
+        request.options?.tools?.map(tool => tool.name),
+        expectedTools,
+      )
+      assert.equal(
+        request.options?.tools?.some(tool =>
+          ['write_file', 'run_command', 'spawn_agent'].includes(tool.name)
+        ),
+        false,
+      )
+    }
+  })
+
+  it('closes a running worker by aborting its model request', async () => {
+    let requestSignal: AbortSignal | undefined
+    let markStarted: (() => void) | undefined
+    const started = new Promise<void>(resolve => {
+      markStarted = resolve
+    })
+    const model: ModelAdapter = {
+      async next(_messages, options): Promise<AgentStep> {
+        requestSignal = options?.signal
+        markStarted?.()
+        return await new Promise<AgentStep>((_resolve, reject) => {
+          const rejectForAbort = () => reject(
+            requestSignal?.reason ?? new Error('aborted'),
+          )
+          if (requestSignal?.aborted) {
+            rejectForAbort()
+            return
+          }
+          requestSignal?.addEventListener('abort', rejectForAbort, { once: true })
+        })
+      },
+    }
+    const manager = new SubAgentManager({
+      model,
+      tools: new ToolRegistry([]),
+      cwd: process.cwd(),
+    })
+    const agent = manager.spawn('keep looking forever')
+
+    await started
+    const closed = await manager.close(agent.id)
+
+    assert.equal(requestSignal?.aborted, true)
+    assert.equal(closed.status, 'closed')
+    assert.ok(closed.finishedAt)
+    assert.equal(manager.runningCount, 0)
+  })
+
+  it('returns current state on wait timeout without closing the worker', async () => {
+    const model: ModelAdapter = {
+      async next(_messages, options): Promise<AgentStep> {
+        return await new Promise<AgentStep>((_resolve, reject) => {
+          const signal = options?.signal
+          const rejectForAbort = () => reject(
+            signal?.reason ?? new Error('aborted'),
+          )
+          if (signal?.aborted) {
+            rejectForAbort()
+            return
+          }
+          signal?.addEventListener('abort', rejectForAbort, { once: true })
+        })
+      },
+    }
+    const manager = new SubAgentManager({
+      model,
+      tools: new ToolRegistry([]),
+      cwd: process.cwd(),
+    })
+    const agent = manager.spawn('slow task')
+
+    const result = await manager.wait([agent.id], 1)
+
+    assert.equal(result.timedOut, true)
+    assert.equal(result.agents[0]?.status, 'running')
+    await manager.close(agent.id)
+  })
+})


### PR DESCRIPTION
# feat: add minimal read-only sub-agent orchestration

## Summary

承接 Issue #41 ，为 MiniCode 增加教学向 multi-agent MVP：root 最多并发启动 3 个只读 worker，并可查询、等待或主动关闭；代码修改权限仍只属于 root

## Key changes

- 模型请求支持按 agent 传入工具列表和 `AbortSignal`
- 新增内存态 `SubAgentManager` 和 `spawn_agent` / `list_agents` / `wait_agent` / `close_agent`
- worker 仅开放文件读取、搜索、skill 加载和 Web 查询工具，禁止写入、命令执行及嵌套 agent
- TUI 底栏显示高亮的 sub-agent 运行数量
- 补充中英文架构说明、路线图和测试

## Verification

- `npm run check`
- `npm run lint`
- `npm test`：228 tests passed
- MiniCode CLI 本地若干手跑测试，使用 dsv4

<img width="3360" height="1710" alt="4ca9a03297dfd3ba371f95c0ccfd14a9" src="https://github.com/user-attachments/assets/17f00ad6-b048-4040-a18b-5c033cca6950" />
<img width="3360" height="1710" alt="01b50b35734cc2edffa1197db67d878b" src="https://github.com/user-attachments/assets/bee1d5e5-7c00-4479-a8e8-ec1f9e3e4e6f" />


## 后续长期目标
- 可写的 sub-agent、并发锁、嵌套 sub-agent、持久化等