### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ Management commands include `minicode mcp ...` and `minicode skills ...`. See [C
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=LiuMengxuan04%2FMiniCode&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#LiuMengxuan04/MiniCode&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=LiuMengxuan04/MiniCode&type=date&theme=dark&legend=bottom-right" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=LiuMengxuan04/MiniCode&type=date&legend=bottom-right" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=LiuMengxuan04/MiniCode&type=date&legend=bottom-right" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=LiuMengxuan04/MiniCode&type=date&theme=dark&legend=bottom-right" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=LiuMengxuan04/MiniCode&type=date&legend=bottom-right" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=LiuMengxuan04/MiniCode&type=date&legend=bottom-right" />
  </picture>
 </a>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -198,10 +198,10 @@ MINI_CODE_MODEL_MODE=mock npm run dev
 ## Star 趋势
 
 <p align="center">
-  <a href="https://star-history.com/#LiuMengxuan04/MiniCode&Date">
+  <a href="https://star-history.dera.page/#LiuMengxuan04/MiniCode&Date">
     <img
       alt="Star History Chart"
-      src="https://api.star-history.com/image?repos=LiuMengxuan04/MiniCode&style=landscape1"
+      src="https://star-history.dera.page/svg?repos=LiuMengxuan04/MiniCode&style=landscape1"
     />
   </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is broken and needs to be fixed. Update the chart links to use star-history.dera.page so the chart displays correctly again.