### PR TITLE
fix: honor settings.json env over process environment variables

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -200,12 +200,26 @@ export async function saveMiniCodeSettings(
   )
 }
 
+/**
+ * Merge process environment variables with env entries from settings files.
+ *
+ * Priority follows the documented configuration precedence (USAGE.md):
+ * `~/.mini-code/settings.json` env entries take precedence over process
+ * environment variables.
+ */
+export function mergeEnv(
+  settingsEnv: MiniCodeSettings['env'] | undefined,
+  processEnv: NodeJS.ProcessEnv,
+): Record<string, string | number | undefined> {
+  return {
+    ...processEnv,
+    ...(settingsEnv ?? {}),
+  }
+}
+
 export async function loadRuntimeConfig(): Promise<RuntimeConfig> {
   const effectiveSettings = await loadEffectiveSettings()
-  const env = {
-    ...(effectiveSettings.env ?? {}),
-    ...process.env,
-  }
+  const env = mergeEnv(effectiveSettings.env, process.env)
 
   const model =
     process.env.MINI_CODE_MODEL ||

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mergeEnv } from '../src/config.js'
+
+describe('mergeEnv', () => {
+  test('settings env overrides process env for the same key', () => {
+    const env = mergeEnv(
+      { ANTHROPIC_BASE_URL: 'https://settings.example.com' },
+      { ANTHROPIC_BASE_URL: 'https://process.example.com' },
+    )
+    assert.equal(env.ANTHROPIC_BASE_URL, 'https://settings.example.com')
+  })
+
+  test('process env values are preserved when not present in settings', () => {
+    const env = mergeEnv(
+      { ANTHROPIC_MODEL: 'custom-model' },
+      { HOME: '/home/user', PATH: '/usr/bin' },
+    )
+    assert.equal(env.HOME, '/home/user')
+    assert.equal(env.PATH, '/usr/bin')
+    assert.equal(env.ANTHROPIC_MODEL, 'custom-model')
+  })
+
+  test('undefined settings env yields process env only', () => {
+    const env = mergeEnv(undefined, { PATH: '/bin' })
+    assert.equal(env.PATH, '/bin')
+  })
+
+  test('empty settings env does not drop process env', () => {
+    const env = mergeEnv({}, { ANTHROPIC_API_KEY: 'sk-test' })
+    assert.equal(env.ANTHROPIC_API_KEY, 'sk-test')
+  })
+})


### PR DESCRIPTION
## What

Fixes #38: env entries in `~/.mini-code/settings.json` are now honored over process environment variables, matching the documented precedence in USAGE.md (settings.json > ... > process env).

Previously `loadRuntimeConfig()` merged env as `{ ...settings.env, ...process.env }`, so system env vars always won. The merge is now extracted into a pure `mergeEnv()` helper with the documented order (`process.env` first, settings env last) and is covered by regression tests.

## Why

The code contradicted the documented configuration priority (USAGE.md "Configuration priority": `~/.mini-code/settings.json` is #1, process environment variables are last). A user setting `ANTHROPIC_BASE_URL` in settings.json would silently get overridden by a system-wide env var.

## Design notes

- Kept the change minimal and focused: a small pure helper instead of restructuring `loadRuntimeConfig`.
- Existing precedence for the `MINI_CODE_*` prefixed variables (`MINI_CODE_MODEL`, `MINI_CODE_MAX_OUTPUT_TOKENS`) is intentionally untouched — those are dedicated overrides and are not part of this issue.
- No new dependencies.

## Verification

- `npm run check` passes
- `npm test` passes (232/232)
- `npm run lint` passes
- New `test/config.test.ts` covers: settings env wins, process env preserved when absent in settings, undefined/empty settings env

## How to review

1. Check `mergeEnv()` in `src/config.ts` — order of spread decides precedence.
2. Run `npm run check && npm test && npm run lint`.