### PR TITLE
feat: show remaining context headroom in TUI badge

### DIFF
--- a/src/tui/chrome.ts
+++ b/src/tui/chrome.ts
@@ -211,9 +211,17 @@ export function renderPanel(
   ].join('\n')
 }
 
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(Math.round(value))
+}
+
 export function renderContextBadge(stats: {
   utilization: number
   warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
+  effectiveInput?: number
+  totalTokens?: number
   accounting?: {
     providerUsageTokens: number
     estimatedTokens: number
@@ -231,7 +239,7 @@ export function renderContextBadge(stats: {
   }
   const color = colorMap[warningLevel]
 
-  const filled = Math.round(utilization * 10)
+  const filled = Math.min(10, Math.max(0, Math.round(utilization * 10)))
   const bar = '\u2593'.repeat(filled) + '\u2591'.repeat(10 - filled)
   const sourceLabel =
     accounting?.source === 'provider_usage'
@@ -241,7 +249,12 @@ export function renderContextBadge(stats: {
         : accounting?.source === 'estimate_only'
           ? 'est'
           : ''
-  const suffix = sourceLabel ? ` ${sourceLabel}` : ''
+  let suffix = sourceLabel ? ` ${sourceLabel}` : ''
+
+  if (stats.effectiveInput !== undefined && stats.totalTokens !== undefined) {
+    const headroom = Math.max(0, stats.effectiveInput - stats.totalTokens)
+    suffix += ` ${formatTokens(headroom)} left`
+  }
 
   return colorBadge('ctx', `${percent}% ${bar}${suffix}`, color)
 }
@@ -261,6 +274,8 @@ export function renderBanner(
     contextStats?: {
       utilization: number
       warningLevel: 'normal' | 'warning' | 'critical' | 'blocked'
+      effectiveInput?: number
+      totalTokens?: number
       accounting?: {
         providerUsageTokens: number
         estimatedTokens: number

--- a/test/context-badge.test.ts
+++ b/test/context-badge.test.ts
@@ -71,4 +71,54 @@ describe('renderContextBadge', () => {
     assert.equal(filledCount, 5, `expected 5 filled blocks, got ${filledCount}`)
     assert.equal(emptyCount, 5, `expected 5 empty blocks, got ${emptyCount}`)
   })
+
+  it('shows remaining headroom when effectiveInput and totalTokens are provided', () => {
+    const result = renderContextBadge({
+      utilization: 0.4,
+      warningLevel: 'normal',
+      effectiveInput: 20_000,
+      totalTokens: 8_000,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('12.0k left'), `expected headroom in: ${plain}`)
+  })
+
+  it('shows raw token count for small headroom', () => {
+    const result = renderContextBadge({
+      utilization: 0.95,
+      warningLevel: 'critical',
+      effectiveInput: 20_000,
+      totalTokens: 19_500,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('500 left'), `expected headroom in: ${plain}`)
+  })
+
+  it('shows zero headroom when context is exhausted', () => {
+    const result = renderContextBadge({
+      utilization: 1,
+      warningLevel: 'blocked',
+      effectiveInput: 10_000,
+      totalTokens: 10_000,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('0 left'), `expected headroom in: ${plain}`)
+  })
+
+  it('does not show headroom when token counts are missing', () => {
+    const result = renderContextBadge({ utilization: 0.4, warningLevel: 'normal' })
+    const plain = stripAnsi(result)
+    assert.ok(!plain.includes('left'))
+  })
+
+  it('clamps negative headroom to zero', () => {
+    const result = renderContextBadge({
+      utilization: 1.05,
+      warningLevel: 'blocked',
+      effectiveInput: 10_000,
+      totalTokens: 12_000,
+    })
+    const plain = stripAnsi(result)
+    assert.ok(plain.includes('0 left'), `expected clamped headroom in: ${plain}`)
+  })
 })


### PR DESCRIPTION
## What

Adds the **remaining context headroom** to the TUI ctx badge (roadmap item in #1). The badge now shows how many tokens are left until the effective input limit, e.g. `ctx 40% ▓▓▓▓░░░░░░ 12.0k left`, instead of only the utilization percentage.

## Why

Users could see how *full* the context was but not how much *room* was left, making it hard to judge when compaction would kick in or whether a long file could still be read. `ContextStats` already carries `effectiveInput` and `totalTokens` end-to-end (agent loop → app state → banner), so the badge just needed to render them.

## Bonus fix

Clamped the bar fill count (`Math.min(10, Math.max(0, ...))`). Previously `utilization > 1` (possible in `blocked` state) made `filled = 11` and crashed with `String.repeat(-1)`. The new test `clamps negative headroom to zero` covers this.

## Design notes

- `effectiveInput` / `totalTokens` are **optional** on the badge input — existing callers and tests that omit them keep the exact previous output (no headroom segment).
- Headroom formatting: `m` / `k` units for large values, raw count below 1000, clamped at 0.

## Verification

- `npm run check` passes
- `npm test` passes (239/239)
- `npm run lint` passes
- `test/context-badge.test.ts` adds 5 cases: headroom shown with token counts, small headroom raw count, zero at exhaustion, omitted counts → no headroom, negative clamped to zero.

## How to review

1. `src/tui/chrome.ts` — `formatTokens` + the headroom suffix in `renderContextBadge`; the fill clamp is a one-line change.
2. Run `npm run check && npm test && npm run lint`.
3. Reproduce: run the app, the ctx badge shows e.g. `12.0k left` while `effectiveInput`/`totalTokens` are available.

Refs #1