### PR TITLE
Add Parallel Search MCP compatibility

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -289,6 +289,29 @@ For vendor compatibility, MiniCode now auto-negotiates stdio framing:
 - for remote MCP over HTTP, use `"protocol": "streamable-http"` with `"url"` (and optional `"headers"`)
 - header values support environment interpolation, e.g. `"Authorization": "Bearer $MCP_TOKEN"`
 
+To opt in to Parallel's hosted web search and URL fetching, add this server to
+`~/.mini-code/mcp.json` or the current project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "protocol": "streamable-http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+The endpoint works without an account or API key and advertises both
+`web_search` and `web_fetch`. MiniCode exposes them through its normal MCP tool
+wrapping as `mcp__parallel-search__web_search` and
+`mcp__parallel-search__web_fetch`; it does not replace the built-in web tools or
+select Parallel by default. When you explicitly configure this server and use
+its tools, user-provided search objectives and search queries are sent to
+Parallel for searches, and user-requested page URLs are sent to Parallel when
+`web_fetch` is invoked. See the [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).
+
 Remote MCP authentication strategy (lightweight by design):
 
 - use `minicode mcp login <name> --token <bearer-token>` to store a bearer token locally

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -146,7 +146,24 @@ function formatContentBlock(block: unknown): string {
   return JSON.stringify(block, null, 2)
 }
 
-function formatToolCallResult(result: unknown): ToolResult {
+function isParallelSearchMcpEndpoint(url: string | undefined): boolean {
+  if (!url?.trim()) return false
+
+  try {
+    const endpoint = new URL(url)
+    return (
+      endpoint.origin === 'https://search.parallel.ai' &&
+      endpoint.pathname.replace(/\/+$/, '') === '/mcp'
+    )
+  } catch {
+    return false
+  }
+}
+
+function formatToolCallResult(
+  result: unknown,
+  preferStructuredContent = false,
+): ToolResult {
   if (!result || typeof result !== 'object') {
     return {
       ok: true,
@@ -162,14 +179,18 @@ function formatToolCallResult(result: unknown): ToolResult {
 
   const parts: string[] = []
 
-  if (Array.isArray(typedResult.content) && typedResult.content.length > 0) {
-    parts.push(typedResult.content.map(formatContentBlock).join('\n\n'))
-  }
+  if (preferStructuredContent && typedResult.structuredContent !== undefined) {
+    parts.push(JSON.stringify(typedResult.structuredContent, null, 2))
+  } else {
+    if (Array.isArray(typedResult.content) && typedResult.content.length > 0) {
+      parts.push(typedResult.content.map(formatContentBlock).join('\n\n'))
+    }
 
-  if (typedResult.structuredContent !== undefined) {
-    parts.push(
-      `STRUCTURED_CONTENT:\n${JSON.stringify(typedResult.structuredContent, null, 2)}`,
-    )
+    if (typedResult.structuredContent !== undefined) {
+      parts.push(
+        `STRUCTURED_CONTENT:\n${JSON.stringify(typedResult.structuredContent, null, 2)}`,
+      )
+    }
   }
 
   if (parts.length === 0) {
@@ -867,7 +888,10 @@ class StreamableHttpMcpClient {
       name,
       arguments: input ?? {},
     })
-    return formatToolCallResult(result)
+    return formatToolCallResult(
+      result,
+      isParallelSearchMcpEndpoint(this.config.url),
+    )
   }
 
   async close(): Promise<void> {

--- a/test/parallel-mcp.test.ts
+++ b/test/parallel-mcp.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import test from 'node:test'
+import { createMcpBackedTools } from '../src/mcp.js'
+import { createDefaultToolRegistry, hydrateMcpTools } from '../src/tools/index.js'
+
+const searchResult = {
+  results: [
+    {
+      url: 'https://example.com/result',
+      title: null,
+      excerpts: ['Canonical result excerpt.'],
+    },
+  ],
+}
+
+async function withMcpServer(
+  run: (url: string, requests: Array<{ method?: string; params?: unknown; headers?: Record<string, string | string[] | undefined> }>) => Promise<void>,
+): Promise<void> {
+  const requests: Array<{ method?: string; params?: unknown; headers?: Record<string, string | string[] | undefined> }> = []
+  const server = createServer(async (request, response) => {
+    const chunks: Buffer[] = []
+    for await (const chunk of request) chunks.push(Buffer.from(chunk))
+    const message = JSON.parse(Buffer.concat(chunks).toString('utf8')) as {
+      id?: number
+      method?: string
+      params?: unknown
+    }
+    requests.push({ ...message, headers: request.headers })
+
+    let result: unknown = {}
+    if (message.method === 'initialize') {
+      result = { protocolVersion: '2024-11-05', capabilities: {}, serverInfo: { name: 'mock', version: '1' } }
+    } else if (message.method === 'tools/list') {
+      result = {
+        tools: [
+          {
+            name: 'web_search',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                objective: { type: 'string' },
+                search_queries: { type: 'array', items: { type: 'string' } },
+              },
+              required: ['objective', 'search_queries'],
+              additionalProperties: false,
+            },
+          },
+          {
+            name: 'web_fetch',
+            inputSchema: {
+              type: 'object',
+              properties: { urls: { type: 'array', items: { type: 'string' } } },
+              required: ['urls'],
+              additionalProperties: false,
+            },
+          },
+        ],
+      }
+    } else if (message.method === 'resources/list') {
+      result = { resources: [] }
+    } else if (message.method === 'prompts/list') {
+      result = { prompts: [] }
+    } else if (message.method === 'tools/call') {
+      const params = message.params as { name?: string; arguments?: unknown }
+      if (params.name === 'web_search') {
+        const args = params.arguments as { objective?: string }
+        result = args.objective === 'Force an MCP error'
+          ? {
+              isError: true,
+              structuredContent: { error: 'Parallel search failed' },
+              content: [{ type: 'text', text: 'mirrored error' }],
+            }
+          : {
+              structuredContent: searchResult,
+              content: [{ type: 'text', text: JSON.stringify(searchResult) }],
+            }
+      } else if (params.name === 'web_fetch') {
+        result = {
+          structuredContent: { pages: [{ url: 'https://example.com/requested', excerpts: ['Requested page excerpt.'], title: null }] },
+          content: [{ type: 'text', text: 'mirrored fetch payload' }],
+        }
+      }
+    }
+
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.end(JSON.stringify({ jsonrpc: '2.0', id: message.id, result }))
+  })
+
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  assert(address && typeof address === 'object')
+  try {
+    await run(`http://127.0.0.1:${address.port}/mcp`, requests)
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  }
+}
+
+test('Parallel Streamable HTTP discovers and calls both hosted tools without duplicate payloads', async () => {
+  await withMcpServer(async (url, requests) => {
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (input, init) => {
+      const target = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      return originalFetch(target === 'https://search.parallel.ai/mcp' ? url : input, init)
+    }
+
+    const customHeader = 'kept-by-minicode'
+    let mcp: Awaited<ReturnType<typeof createMcpBackedTools>> | undefined
+    try {
+      mcp = await createMcpBackedTools({
+        cwd: process.cwd(),
+        mcpServers: {
+          'parallel-search': {
+            command: '',
+            url: 'https://search.parallel.ai/mcp',
+            protocol: 'streamable-http',
+            headers: { 'X-User-Header': customHeader },
+          },
+        },
+      })
+      assert.deepEqual(mcp.tools.map(tool => tool.name), [
+        'mcp__parallel-search__web_search',
+        'mcp__parallel-search__web_fetch',
+      ])
+
+      const search = mcp.tools[0]
+      const searchOutput = await search.run({
+        objective: 'Find current MCP compatibility information',
+        search_queries: ['MiniCode MCP Streamable HTTP'],
+      }, { cwd: process.cwd() })
+      assert.equal(searchOutput.ok, true)
+      assert.equal(searchOutput.output, JSON.stringify(searchResult, null, 2))
+      assert.equal(searchOutput.output.match(/Canonical result excerpt\./g)?.length, 1)
+      assert.equal(JSON.stringify(requests).includes('https://example.com/requested'), false)
+
+      const fetchTool = mcp.tools[1]
+      const fetchOutput = await fetchTool.run(
+        { urls: ['https://example.com/requested'] },
+        { cwd: process.cwd() },
+      )
+      assert.equal(fetchOutput.ok, true)
+      assert.match(fetchOutput.output, /Requested page excerpt\./)
+
+      const errorOutput = await search.run(
+        { objective: 'Force an MCP error', search_queries: ['failing query'] },
+        { cwd: process.cwd() },
+      )
+      assert.equal(errorOutput.ok, false)
+      assert.equal(errorOutput.output, JSON.stringify({ error: 'Parallel search failed' }, null, 2))
+      assert(requests.every(request => request.headers?.['x-user-header'] === customHeader))
+
+      const calls = requests.filter(request => request.method === 'tools/call')
+      assert.deepEqual(calls.map(call => call.params), [
+        {
+          name: 'web_search',
+          arguments: {
+            objective: 'Find current MCP compatibility information',
+            search_queries: ['MiniCode MCP Streamable HTTP'],
+          },
+        },
+        {
+          name: 'web_fetch',
+          arguments: { urls: ['https://example.com/requested'] },
+        },
+        {
+          name: 'web_search',
+          arguments: {
+            objective: 'Force an MCP error',
+            search_queries: ['failing query'],
+          },
+        },
+      ])
+    } finally {
+      await mcp?.dispose()
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+test('generic MCP formatting and the default no-server registry stay unchanged', async () => {
+  const registry = await createDefaultToolRegistry({ cwd: process.cwd(), runtime: null })
+  assert(registry.find('web_search'))
+  assert(registry.find('web_fetch'))
+  await hydrateMcpTools({ cwd: process.cwd(), runtime: null, tools: registry })
+  assert.deepEqual(registry.getMcpServers(), [])
+  await registry.dispose()
+
+  await withMcpServer(async (url) => {
+    const mcp = await createMcpBackedTools({
+      cwd: process.cwd(),
+      mcpServers: { custom: { command: '', url, headers: { 'X-User-Header': 'preserved' } } },
+    })
+    try {
+      const result = await mcp.tools[0].run(
+        { objective: 'custom', search_queries: ['custom'] },
+        { cwd: process.cwd() },
+      )
+      assert.match(result.output, /Canonical result excerpt\./)
+      assert.match(result.output, /STRUCTURED_CONTENT:/)
+    } finally {
+      await mcp.dispose()
+    }
+  })
+})


### PR DESCRIPTION
## What changed

- Document an optional Streamable HTTP configuration for `https://search.parallel.ai/mcp`, which requires no account or API key and exposes both `web_search` and `web_fetch` through MiniCode's existing generic MCP tool wrapping.
- Prefer `structuredContent` for this Parallel endpoint when a response also mirrors the same payload as JSON text, preventing duplicate results while leaving other MCP server result shapes unchanged.
- Add a strict runtime test covering discovery and invocation of both hosted tools, nullable titles and excerpt arrays, error propagation, preserved user headers, unchanged custom-server formatting, and the unchanged built-in/no-server defaults.

Parallel is not selected by default. After a user explicitly configures this MCP server, search objectives and search queries are sent to Parallel when `web_search` is invoked, and user-requested page URLs are sent to Parallel when `web_fetch` is invoked.

## Why

This uses MiniCode's existing native Streamable HTTP MCP path and keeps the compatibility change small: no new dependency, provider allowlist, or replacement of the built-in web tools.

## Validation

- `npm run check`
- `npm run lint`
- `npm test`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.