### PR TITLE
fix: scope one-time edit approvals to a single edit

### DIFF
--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -164,7 +164,6 @@ export class PermissionManager {
   private readonly sessionDeniedCommands = new Set<string>()
   private readonly allowedEditPatterns = new Set<string>()
   private readonly deniedEditPatterns = new Set<string>()
-  private readonly sessionAllowedEdits = new Set<string>()
   private readonly sessionDeniedEdits = new Set<string>()
   private readonly turnAllowedEdits = new Set<string>()
   private turnAllowAllEdits = false
@@ -419,7 +418,6 @@ export class PermissionManager {
     }
 
     if (
-      this.sessionAllowedEdits.has(normalizedTarget) ||
       this.turnAllowedEdits.has(normalizedTarget) ||
       this.turnAllowAllEdits ||
       this.allowedEditPatterns.has(normalizedTarget)
@@ -454,7 +452,6 @@ export class PermissionManager {
     })
 
     if (promptResult.decision === 'allow_once') {
-      this.sessionAllowedEdits.add(normalizedTarget)
       return
     }
 
@@ -488,8 +485,6 @@ export class PermissionManager {
     if (promptResult.decision === 'deny_always') {
       this.deniedEditPatterns.add(normalizedTarget)
       await this.persist()
-    } else {
-      this.sessionDeniedEdits.add(normalizedTarget)
     }
 
     throw new Error(`Edit denied: ${normalizedTarget}`)

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  PermissionManager,
+  type PermissionDecision,
+} from '../src/permissions.js'
+
+async function withWorkspace(
+  prefix: string,
+  run: (workspace: string) => Promise<void>,
+): Promise<void> {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), prefix))
+  try {
+    await run(workspace)
+  } finally {
+    await rm(workspace, { recursive: true, force: true })
+  }
+}
+
+describe('edit permission decisions', () => {
+  it('prompts again for a revised diff after allow_once', async () => {
+    await withWorkspace('minicode-allow-once-', async workspace => {
+      const target = path.join(workspace, 'example.ts')
+      const firstDiff = 'diff: first revision'
+      const secondDiff = 'diff: second revision'
+      const promptedDiffs: string[] = []
+      const permissions = new PermissionManager(workspace, async request => {
+        promptedDiffs.push(request.details.at(-1) ?? '')
+        return { decision: 'allow_once' }
+      })
+
+      permissions.beginTurn()
+      await permissions.ensureEdit(target, firstDiff)
+      await permissions.ensureEdit(target, secondDiff)
+
+      assert.deepEqual(promptedDiffs, [firstDiff, secondDiff])
+    })
+  })
+
+  it('prompts again for a revised diff after deny_once', async () => {
+    await withWorkspace('minicode-deny-once-', async workspace => {
+      const target = path.join(workspace, 'example.ts')
+      const firstDiff = 'diff: first rejection'
+      const secondDiff = 'diff: second revision'
+      const promptedDiffs: string[] = []
+      const decisions: PermissionDecision[] = ['deny_once', 'allow_once']
+      const permissions = new PermissionManager(workspace, async request => {
+        const decision = decisions[promptedDiffs.length]
+        assert.ok(decision)
+        promptedDiffs.push(request.details.at(-1) ?? '')
+        return { decision }
+      })
+
+      permissions.beginTurn()
+      await assert.rejects(permissions.ensureEdit(target, firstDiff), /Edit denied/)
+      await permissions.ensureEdit(target, secondDiff)
+
+      assert.deepEqual(promptedDiffs, [firstDiff, secondDiff])
+    })
+  })
+
+  it('limits allow_turn to its file and current turn', async () => {
+    await withWorkspace('minicode-allow-turn-', async workspace => {
+      const firstTarget = path.join(workspace, 'first.ts')
+      const secondTarget = path.join(workspace, 'second.ts')
+      const firstDiff = 'diff: first file initial'
+      const revisedDiff = 'diff: first file revised'
+      const otherFileDiff = 'diff: second file'
+      const nextTurnDiff = 'diff: first file next turn'
+      const promptedDiffs: string[] = []
+      const decisions: PermissionDecision[] = [
+        'allow_turn',
+        'allow_once',
+        'allow_once',
+      ]
+      const permissions = new PermissionManager(workspace, async request => {
+        const decision = decisions[promptedDiffs.length]
+        assert.ok(decision)
+        promptedDiffs.push(request.details.at(-1) ?? '')
+        return { decision }
+      })
+
+      permissions.beginTurn()
+      await permissions.ensureEdit(firstTarget, firstDiff)
+      await permissions.ensureEdit(firstTarget, revisedDiff)
+      await permissions.ensureEdit(secondTarget, otherFileDiff)
+      permissions.endTurn()
+      permissions.beginTurn()
+      await permissions.ensureEdit(firstTarget, nextTurnDiff)
+
+      assert.deepEqual(promptedDiffs, [firstDiff, otherFileDiff, nextTurnDiff])
+    })
+  })
+})


### PR DESCRIPTION
## Problem

The edit approval menu distinguishes one-time, turn-scoped, and persistent
choices, but `allow_once` and `deny_once` were recorded in session-scoped
caches.

A one-time decision therefore applied to every later edit of the same file for
the rest of the session, even when the proposed diff had changed: `apply once`
kept approving them with no prompt, and `reject once` kept rejecting them with
no prompt and no way to re-approve. This also made `apply once` broader than
`allow this file in this turn`.

The session-scoped edit caches predate the turn-scoped choices. Once
`allow this file in this turn` and `allow all edits in this turn` existed, the
one-time branches were still writing to those caches, so the one-time entries
never behaved as one-time.

## Reproduction

1. Run `npm run dev`.
2. Ask the model to propose two different edits to the same file.
3. Choose `1` (`apply once`) for the first edit.

**Before:** the second edit is applied without another prompt or diff review.

**After:** the second edit prompts again and displays its own diff.

Repeat with `5` (`reject once`), which is also what Escape maps to:

**Before:** later edits to the same file fail with `Edit denied` without
another prompt.

**After:** the next edit prompts again and can be approved.

## Changes

- keep `allow_once` local to the current `ensureEdit()` request
- keep `deny_once` local to the current `ensureEdit()` request
- remove the now-unused `sessionAllowedEdits` cache

Turn-scoped and persistent edit choices are unchanged. `sessionDeniedEdits` is
retained because reject-with-guidance still uses it.

Path and command approvals keep their session-scoped `allow once`: those menus
have no turn-scoped option, so the session cache is still the only way to stop
being asked there. The edit menu already offers `2`-`4` for that, which is why
only edits change here.

Choosing `apply once` repeatedly now prompts once per edit. Options `2`-`4`
remain available for approving the file for the turn, all edits for the turn,
or the file permanently. Adding an explicit session-scoped choice to the edit
menu would be a product decision rather than a fix, so it is left out of this
PR.

The production change is a five-line deletion in `src/permissions.ts`. It
introduces no new abstraction, dependency, persistence-format change, or TUI
change. This preserves MiniCode's explicit Claude Code-style approval
hierarchy: broader permissions remain separate choices instead of being
inferred from a one-time response.

No user-facing documentation described the previous session-scoped behavior,
so no documentation change is included.

## Regression tests

Added `test/permissions.test.ts` covering:

- a revised diff prompts again after `allow_once`
- a revised diff prompts again after `deny_once` and can then be approved
- `allow_turn` still covers repeated edits to the same file only within the
  current turn

The first two tests fail on the previous implementation. The `allow_turn`
test is a regression guard and passes before and after the fix.

## Verification

```bash
node --import tsx --test test/permissions.test.ts   # 3 passed
npm run check
npm test                                            # 231 passed
npm run lint
```
